### PR TITLE
Fix a configure error with gcc 4.9

### DIFF
--- a/lib/autoconf/acx_check_gmpxx.m4
+++ b/lib/autoconf/acx_check_gmpxx.m4
@@ -11,7 +11,8 @@ AC_DEFUN([ACX_CHECK_GMPXX], [
   LIBS="-lgmpxx -lgmp $LIBS"
   AC_LINK_IFELSE(
    [AC_LANG_PROGRAM(
-    [[#include <gmpxx.h>
+    [[#include <cstddef>
+      #include <gmpxx.h>
     ]],
     [[
      mpf_class a = 1.0;

--- a/src/bin/libint/key.h
+++ b/src/bin/libint/key.h
@@ -21,6 +21,7 @@
 #define _libint2_src_bin_libint_key_h_
 
 #include <libint2/intrinsic_types.h>
+#include <cstddef>
 #include <gmpxx.h>
 #include <sstream>
 

--- a/src/bin/test_eri/eri.h
+++ b/src/bin/test_eri/eri.h
@@ -24,6 +24,7 @@
 
 #if defined(__cplusplus)
 #if HAVE_MPFR
+# include <cstddef>
 # include <gmpxx.h>
 # include <mpfr.h>
  typedef mpf_class LIBINT2_REF_REALTYPE;


### PR DESCRIPTION
Fixes #29. The problem is described at https://gcc.gnu.org/gcc-4.9/porting_to.html, the `<cstddef>` was updated and must be included before `<gmpxx.h>`.