### PR TITLE
fixed include path handling of in-place vs installed headers to fix #72

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,8 +3,12 @@
 
 Following is a brief summary of changes made in each release of Libint.
 
-- 2017-xx-yy: 2.3.0-beta.4
+- 2017-xx-yy: 2.3.0-beta.5
   - 
+
+- 2017-03-06: 2.3.0-beta.4
+  - fixed include path handling of in-place vs. installed generated headers (HT https://github.com/mfherbst)
+  - fixed 2-norm Schwarz computation in hf++
 
 - 2017-01-12: 2.3.0-beta.3
   - boys.h requires C++11; Chebyshev7 is the default Boys engine, Chebyshev3 is gone.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 define([libint_mmm_version],[2.3.0])
-define([libint_buildid],[beta.3])
+define([libint_buildid],[beta.4])
 define([libint_so_version],[2:2:0])
 
 dnl --------- Begin ---------
@@ -1146,6 +1146,9 @@ AC_SUBST(CXXDEPENDFLAGS)
 dnl -- special architecture options --
 
 # nothing so far
+
+dnl -- extra define for internal includes --
+EXTRADEFINES=-D__COMPILING_LIBINT2=1
 
 AC_SUBST(EXTRAINCLUDE)
 AC_SUBST(EXTRADEFINES)

--- a/export/MakeRules.export
+++ b/export/MakeRules.export
@@ -16,6 +16,8 @@ install_inc:: $(TOPDIR)/lib/$(TARGET)
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2/chemistry/*.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/chemistry
 	$(INSTALL) $(INSTALLDIROPT) $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/util
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2/util/*.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/util
+	$(INSTALL) $(INSTALLDIROPT) $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/util/generated
+	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2/util/generated/*.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/util/generated
 	gunzip -c $(SRCTOPDIR)/external/boost.tar.gz | tar -xf - -C $(DESTDIR)$(includedir)/$(NAME)$(VERSION)
 
 install_pkgconfig::

--- a/export/Makefile
+++ b/export/Makefile
@@ -60,12 +60,14 @@ exportdir::
 	$(INSTALL) $(INSTALLDIROPT) $(TOPDIR)/$(EXPORTDIR)/include/libint2
 	$(INSTALL) $(INSTALLDIROPT) $(TOPDIR)/$(EXPORTDIR)/include/libint2/chemistry
 	$(INSTALL) $(INSTALLDIROPT) $(TOPDIR)/$(EXPORTDIR)/include/libint2/util
+	$(INSTALL) $(INSTALLDIROPT) $(TOPDIR)/$(EXPORTDIR)/include/libint2/util/generated
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2.h $(TOPDIR)/$(EXPORTDIR)/include
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2.hpp $(TOPDIR)/$(EXPORTDIR)/include
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2/*.h $(TOPDIR)/$(EXPORTDIR)/include/libint2
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2/basis.h.in $(TOPDIR)/$(EXPORTDIR)/include/libint2
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2/chemistry/*.h $(TOPDIR)/$(EXPORTDIR)/include/libint2/chemistry
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2/util/*.h $(TOPDIR)/$(EXPORTDIR)/include/libint2/util
+	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/libint2/util/generated/*.h $(TOPDIR)/$(EXPORTDIR)/include/libint2/util/generated
 	-$(INSTALL) $(INSTALLLIBOPT) $(TOPDIR)/include/libint2/config.h $(TOPDIR)/$(EXPORTDIR)/include/libint2/config.h.in
 	-$(INSTALL) $(INSTALLLIBOPT) $(TOPDIR)/include/libint2/cgshell_ordering.h $(TOPDIR)/$(EXPORTDIR)/include/libint2
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/src/bin/libint/util_types.h $(TOPDIR)/$(EXPORTDIR)/include

--- a/export/configure.export
+++ b/export/configure.export
@@ -1,5 +1,5 @@
 define([libint_mmm_version],[2.3.0])
-define([libint_buildid],[beta.3])
+define([libint_buildid],[beta.4])
 define([libint_so_version],[2:2:0])
 
 dnl --------- Begin ---------
@@ -276,9 +276,10 @@ AC_SUBST(CXXDEPENDFLAGS)
 
 
 dnl -------- Checks for architecture specific features. --------
-dnl (Doesn't work for cross compilation.)
-dnl AC_CHECK_SIZEOF(void*)
+# nothing so far
 
+dnl -------- extra define for internal includes --------
+EXTRADEFINES=-D__COMPILING_LIBINT2=1
 AC_SUBST(EXTRADEFINES)
 
 dnl ---------- Checks for header files. -----------

--- a/include/libint2.h
+++ b/include/libint2.h
@@ -29,8 +29,8 @@
 #define LIBINT_T_S_ELECPOT_S(mValue) _aB_s___0___ElecPot_s___0___Ab__up_##mValue
 
 #include <libint2/util/intrinsic_types.h>
-#include <libint2_params.h>
-#include <libint2_types.h>
+#include <libint2/util/generated/libint2_params.h>
+#include <libint2/util/generated/libint2_types.h>
 
 #if defined(__cplusplus)
 # include <libint2/util/type_traits.h>
@@ -42,5 +42,5 @@
 
 #endif /* header guard */
 
-#include "libint2_iface.h"
+#include <libint2/util/generated/libint2_iface.h>
 

--- a/include/libint2/cgshell_ordering.h.in
+++ b/include/libint2/cgshell_ordering.h.in
@@ -23,11 +23,11 @@
 #include <libint2/config.h>
 /* if this is not defined, then using exported source -- redefine using macro from libint2_params.h */
 #ifndef LIBINT_CARTGAUSS_MAX_AM
-# include <libint2_params.h>
+# include <libint2/util/generated/libint2_params.h>
 # define LIBINT_CARTGAUSS_MAX_AM LIBINT2_CARTGAUSS_MAX_AM
 #endif
 #ifndef LIBINT_CGSHELL_ORDERING
-# include <libint2_params.h>
+# include <libint2/util/generated/libint2_params.h>
 # define LIBINT_CGSHELL_ORDERING LIBINT2_CGSHELL_ORDERING
 # define LIBINT_CGSHELL_ORDERING_STANDARD LIBINT2_CGSHELL_ORDERING_STANDARD
 # define LIBINT_CGSHELL_ORDERING_INTV3 LIBINT2_CGSHELL_ORDERING_INTV3

--- a/include/libint2/util/generated/libint2_iface.h
+++ b/include/libint2/util/generated/libint2_iface.h
@@ -1,0 +1,30 @@
+/*
+ *  This file is a part of Libint.
+ *  Copyright (C) 2004-2017 Edward F. Valeev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+
+#ifndef _libint2_include_libint2_util_preprocessor_libint2iface_h_
+#define _libint2_include_libint2_util_preprocessor_libint2iface_h_
+
+#ifndef __COMPILING_LIBINT2
+#  include <libint2/libint2_iface.h>
+#else
+#  include <libint2_iface.h>
+#endif
+
+#endif /* _libint2_include_libint2_util_preprocessor_libint2iface_h_ */

--- a/include/libint2/util/generated/libint2_params.h
+++ b/include/libint2/util/generated/libint2_params.h
@@ -1,0 +1,30 @@
+/*
+ *  This file is a part of Libint.
+ *  Copyright (C) 2004-2017 Edward F. Valeev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+
+#ifndef _libint2_include_libint2_util_preprocessor_libint2params_h_
+#define _libint2_include_libint2_util_preprocessor_libint2params_h_
+
+#ifndef __COMPILING_LIBINT2
+#  include <libint2/libint2_params.h>
+#else
+#  include <libint2_params.h>
+#endif
+
+#endif /* _libint2_include_libint2_util_preprocessor_libint2params_h_ */

--- a/include/libint2/util/generated/libint2_types.h
+++ b/include/libint2/util/generated/libint2_types.h
@@ -1,0 +1,30 @@
+/*
+ *  This file is a part of Libint.
+ *  Copyright (C) 2004-2017 Edward F. Valeev
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+
+#ifndef _libint2_include_libint2_util_preprocessor_libint2types_h_
+#define _libint2_include_libint2_util_preprocessor_libint2types_h_
+
+#ifndef __COMPILING_LIBINT2
+#  include <libint2/libint2_types.h>
+#else
+#  include <libint2_types.h>
+#endif
+
+#endif /* _libint2_include_libint2_util_preprocessor_libint2types_h_ */

--- a/include/libint2/util/memory.h
+++ b/include/libint2/util/memory.h
@@ -20,7 +20,7 @@
 #define _libint2_src_lib_libint_libint2memory_h_
 
 #include <cstdlib>
-#include <libint2_params.h>
+#include <libint2/util/generated/libint2_params.h>
 
 namespace libint2 {
 

--- a/src/lib/MakeRules.in
+++ b/src/lib/MakeRules.in
@@ -24,6 +24,7 @@ install_inc:: $(TOPDIR)/lib/$(TARGET)
 	$(INSTALL) $(INSTALLDIROPT) $(DESTDIR)$(includedir)/$(NAME)$(VERSION)
 	$(INSTALL) $(INSTALLDIROPT) $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/chemistry
 	$(INSTALL) $(INSTALLDIROPT) $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/util
+	$(INSTALL) $(INSTALLDIROPT) $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/util/generated
 	-$(INSTALL) $(INSTALLLIBOPT) $(TOPDIR)/include/$(NAME)$(VERSION)/*.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)
 	-$(INSTALL) $(INSTALLLIBOPT) $(TOPDIR)/include/$(NAME)$(VERSION)/config.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/$(NAME)$(VERSION).h $(DESTDIR)$(includedir)
@@ -31,6 +32,7 @@ install_inc:: $(TOPDIR)/lib/$(TARGET)
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/$(NAME)$(VERSION)/*.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/$(NAME)$(VERSION)/chemistry/*.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/chemistry
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/$(NAME)$(VERSION)/util/*.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/util
+	-$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/include/$(NAME)$(VERSION)/util/generated/*.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)/util/generated
 	-$(INSTALL) $(INSTALLLIBOPT) $(SRCDIR)/*.h $(DESTDIR)$(includedir)/$(NAME)$(VERSION)
 	gunzip -c $(SRCTOPDIR)/external/boost.tar.gz | tar -xf - -C $(DESTDIR)$(includedir)/$(NAME)$(VERSION)
 


### PR DESCRIPTION
This is just a clean-up of the proposed solution by @mfherbst that avoids relocating the to-be-installed generated headers.