### PR TITLE
Update link to reflect new gaussian website layout

### DIFF
--- a/include/libint2/basis.h.in
+++ b/include/libint2/basis.h.in
@@ -190,7 +190,7 @@ namespace libint2 {
         return result;
       }
 
-      // see http://www.gaussian.com/g_tech/g_ur/m_basis_sets.htm
+      // see http://gaussian.com/basissets/
       bool gaussian_cartesian_d_convention(const std::string& canonical_name) {
         // 3-21??g??, 4-31g??
         if (canonical_name.find("3-21")    == 0 ||


### PR DESCRIPTION
By the way: I am not sure whether this library intends to fully follow the convention of the Gaussian folks. 
If yes, than the present code fails to use cartesian d-functions with the basis set ``6-21G``. See the tab  *Pure vs. Cartesian* on http://gaussian.com/basissets/ for details.

In either case: It's not that big an issue, since libint does not ship ``6-21G`` anyway.