### PR TITLE
Adds alternate CMake build system to v1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_policy(SET CMP0048 NEW)  # project_VERSION* variables populated from project(... VERSION x.x.x) string
+
+project(Libint
+        VERSION 1.2.0
+        LANGUAGES C CXX)
+set(Libint_AUTHORS      "Edward F. Valeev and Justin T. Fermann")
+set(Libint_DESCRIPTION  "Parallel implementation of the Effective Fragment Potential (EFP) method")
+set(Libint_URL          "https://libefp.github.io/")
+set(Libint_LICENSE      "GPL-3.0 for generator; LGPL-3.0 for generated")
+
+cmake_minimum_required(VERSION 3.0)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+################################### Options ####################################
+include(psi4OptionsTools)
+option_with_default(CMAKE_BUILD_TYPE "Build type" Release)
+option_with_default(MAX_AM_ERI "Maximum angular momentum for integrals (min value 3)" 5)
+option_with_print(BUILD_SHARED_LIBS "Build final library as shared, not static" OFF)
+option_with_default(BUILD_FPIC "Libraries will be compiled with position independent code" ON)
+if(${BUILD_SHARED_LIBS} AND NOT ${BUILD_FPIC})
+    message(FATAL_ERROR "BUILD_SHARED_LIBS ON and BUILD_FPIC OFF are incompatible, as shared library requires position independent code")
+endif()
+option_with_print(ENABLE_GENERIC "Enable mostly static linking in shared library" OFF)
+option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON
+                    "-xHost" "-march=native")
+# CODE_COVERAGE should be tested and probably propagated to external projects
+#option_with_flags(ENABLE_CODE_COVERAGE "Enables details on code coverage" OFF
+#                    "-ftest-coverage")
+
+######################### Process & Validate Options ###########################
+include(autocmake_safeguards)
+include(autocmake_static_library)
+
+################################# Main Project #################################
+set(STAGED_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/stage${CMAKE_INSTALL_PREFIX})
+
+add_subdirectory(src)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(PN ${PROJECT_NAME})
+
+# <<<  Install  >>>
+
+install(DIRECTORY ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+                  ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+                  ${STAGED_INSTALL_PREFIX}/share
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
+        USE_SOURCE_PERMISSIONS
+        PATTERN "*header*" EXCLUDE)
+
+# <<<  Export Config  >>>
+
+# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
+set(CMAKECONFIG_INSTALL_DIR "share/cmake/${PN}")
+configure_package_config_file(cmake/${PN}Config.cmake.in
+                              "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
+                              INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
+                                 VERSION ${${PN}_VERSION}
+                                 COMPATIBILITY SameMajorVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
+        DESTINATION ${CMAKECONFIG_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(Libint
         VERSION 1.2.0
         LANGUAGES C CXX)
 set(Libint_AUTHORS      "Edward F. Valeev and Justin T. Fermann")
-set(Libint_DESCRIPTION  "Parallel implementation of the Effective Fragment Potential (EFP) method")
-set(Libint_URL          "https://libefp.github.io/")
+set(Libint_DESCRIPTION  "Library for the evaluation of molecular integrals of two-body operators over Gaussian functions")
+set(Libint_URL          "http://libint.valeyev.net")
 set(Libint_LICENSE      "GPL-3.0 for generator; LGPL-3.0 for generated")
 
 cmake_minimum_required(VERSION 3.0)
@@ -23,9 +23,7 @@ endif()
 option_with_print(ENABLE_GENERIC "Enable mostly static linking in shared library" OFF)
 option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON
                     "-xHost" "-march=native")
-# CODE_COVERAGE should be tested and probably propagated to external projects
-#option_with_flags(ENABLE_CODE_COVERAGE "Enables details on code coverage" OFF
-#                    "-ftest-coverage")
+option_with_print(MERGE_LIBDERIV_INCLUDEDIR "Install libderiv headers to libint namespace. Psi4 wants ON" OFF)
 
 ######################### Process & Validate Options ###########################
 include(autocmake_safeguards)

--- a/README_CMake.md
+++ b/README_CMake.md
@@ -1,0 +1,74 @@
+# Libint
+
+### History
+
+This is the Libint project (http://evaleev.github.io/libint/) by
+Prof. Edward F. Valeev (@evaleev) with early roots by Prof. Justin T.
+Fermann.
+
+Libint1 has source available on sourceforge 
+(https://sourceforge.net/projects/libint/files/v1-releases/) or in this repository as a branch on GitHub
+(https://github.com/evaleev/libint/tree/v1) and primarily
+builds with `make`. Libint1 separates the build process for derivative integrals.
+
+Libint2 has source available on GitHub (https://github.com/evaleev/libint) and,
+as distributed, builds with `make`. Libint2 integrates the build process for
+derivative integrals.
+
+Libint1 and Libderiv1 have been in the *ab initio* quantum chemistry package Psi4
+(http://psicode.org/, https://github.com/psi4/psi4) since 2009. Internal to Psi4, it
+has, since about 2014, built with `cmake`, as designed by @andysim.
+@ryanmrichard and @loriab have reworked the CMake build and extracted the
+project until suitable for `ExternalProject_Add`. As of version 1.2.0,
+Psi4's CMake build system for libint1 and libderiv1 source has been
+ported back to this main Libint repository as an alternate build system.
+
+#### Building
+
+```bash
+cmake -H. -Bobjdir \
+ -DMAX_AM_ERI=4
+cd objdir && make
+make install 
+```
+
+The primary CMake option is `MAX_AM_ERI` to control the maximum angular
+momentum for integrals. This is a Psi4 quantity slightly different from
+those used internally by Libint and found in the installed header files:
+
+`MAX_AM_ERI` | `LIBINT_MAX_AM` | `LIBINT_OPT_AM` | `LIBDERIV_MAX_AM1` | `LIBDERIV_MAX_AM12`
+------------ | --------------- | --------------- | ------------------ | -------------------
+3 | 4 | 4 | 3 | 2
+4 | 5 | 3 | 4 | 3
+**5** | **6** | **3** | **5** | **4**
+6 | 7 | 4 | 6 | 5
+7 | 8 | 4 |
+8 | 9 | 5 |
+
+For orientation on an atom such as Neon, the default **5** gets you conventional cc-pV5Z for energies, cc-pVQZ for gradients, cc-pVTZ for frequencies and density-fitted cc-pVQZ for energies, cc-pVTZ for gradients, cc-pVDZ for frequencies.
+
+The build is also responsive to 
+
+* static/shared toggle `BUILD_SHARED_LIBS`
+* the install location `CMAKE_INSTALL_PREFIX`
+* of course, `CMAKE_C_COMPILER`, `CMAKE_CXX_COMPILER`, `CMAKE_C_FLAGS`, and `CMAKE_CXX_FLAGS`
+
+See [CMakeLists.txt](CMakeLists.txt) for options details and additional options. All these build options should be passed as `cmake -DOPTION`.
+
+#### Detecting
+
+This project installs with `LibintConfig.cmake` and `LibintConfigVersion.cmake` files suitable for use with CMake [`find_package()`](https://cmake.org/cmake/help/v3.2/command/find_package.html) in `CONFIG` mode.
+
+* `find_package(Libint)` - find any Libint libraries and headers
+* `find_package(Libint 1.1.6 EXACT CONFIG REQUIRED COMPONENTS shared 6)` - find Libint exactly version 1.1.6 built with shared libraries and `MAX_AM_ERI` >= 6 or die trying
+
+See [LibintConfig.cmake.in](cmake/LibintConfig.cmake.in) for details of how to detect the Config file and what CMake variables and targets are exported to your project.
+
+#### Using
+
+After `find_package(Libint ...)`,
+
+* test if package found with `if(${Libint_FOUND})` or `if(TARGET Libint::libint)`
+* link to library (establishes dependency), including header and definitions configuration with `target_link_libraries(mytarget Libint::libint)`
+* include header files using `target_include_directories(mytarget PRIVATE $<TARGET_PROPERTY:Libint::libint,INTERFACE_INCLUDE_DIRECTORIES>)`
+* compile target applying `-DUSING_Libint;-DMAX_AM_ERI=N` definition using `target_compile_definitions(mytarget PRIVATE $<TARGET_PROPERTY:Libint::libint,INTERFACE_COMPILE_DEFINITIONS>)`

--- a/cmake/FindStandardMathLibraryC.cmake
+++ b/cmake/FindStandardMathLibraryC.cmake
@@ -1,0 +1,54 @@
+# * downloaded Nov 2016 from https://android.googlesource.com/platform/external/eigen/+/master/cmake/FindStandardMathLibrary.cmake
+# * changed CXX to C
+# * note that full path to libm *not* detected
+
+# - Try to find how to link to the standard math library, if anything at all is needed to do.
+# On most platforms this is automatic, but for example it's not automatic on QNX.
+#
+# Once done this will define
+#
+#  STANDARD_MATH_LIBRARY_FOUND - we found how to successfully link to the standard math library
+#  STANDARD_MATH_LIBRARY - the name of the standard library that one has to link to.
+#                            -- this will be left empty if it's automatic (most platforms).
+#                            -- this will be set to "m" on platforms where one must explicitly
+#                               pass the "-lm" linker flag.
+#
+# Copyright (c) 2010 Benoit Jacob <jacob.benoit.1@gmail.com>
+# Redistribution and use is allowed according to the terms of the 2-clause BSD license.
+include(CheckCSourceCompiles)
+# a little test program for c++ math functions.
+# notice the std:: is required on some platforms such as QNX
+set(find_standard_math_library_test_program
+"#include<math.h>
+int main() { sin(0.0); log(0.0f); }")
+# C++ test program
+# "#include<cmath>
+# int main() { std::sin(0.0); std::log(0.0f); }")
+# first try compiling/linking the test program without any linker flags
+set(CMAKE_REQUIRED_FLAGS "")
+set(CMAKE_REQUIRED_LIBRARIES "")
+CHECK_C_SOURCE_COMPILES(
+  "${find_standard_math_library_test_program}"
+  standard_math_library_linked_to_automatically
+)
+if(standard_math_library_linked_to_automatically)
+  # the test program linked successfully without any linker flag.
+  set(STANDARD_MATH_LIBRARY "")
+  set(STANDARD_MATH_LIBRARY_FOUND TRUE)
+else()
+  # the test program did not link successfully without any linker flag.
+  # This is a very uncommon case that so far we only saw on QNX. The next try is the
+  # standard name 'm' for the standard math library.
+  set(CMAKE_REQUIRED_LIBRARIES "m")
+  CHECK_C_SOURCE_COMPILES(
+    "${find_standard_math_library_test_program}"
+    standard_math_library_linked_to_as_m)
+  if(standard_math_library_linked_to_as_m)
+    # the test program linked successfully when linking to the 'm' library
+    set(STANDARD_MATH_LIBRARY "m")
+    set(STANDARD_MATH_LIBRARY_FOUND TRUE)
+  else()
+    # the test program still doesn't link successfully
+    set(STANDARD_MATH_LIBRARY_FOUND FALSE)
+  endif()
+endif()

--- a/cmake/LibintConfig.cmake.in
+++ b/cmake/LibintConfig.cmake.in
@@ -1,0 +1,178 @@
+# LibintConfig.cmake
+# ------------------
+#
+# Libint cmake module.
+# This module sets the following variables in your project:
+#
+# ::
+#
+#   Libint_FOUND - true if Libint and all required components found on the system
+#   Libint_VERSION - Libint version in format Major.Minor.Release
+#   Libint_INCLUDE_DIRS - Directories where Libint and libderiv headers are located.
+#   Libint_INCLUDE_DIR - same as DIRS
+#   Libint_DEFINITIONS - definitions necessary to use Libint
+#   Libint_LIBRARIES - Libint and libderiv libraries to link against.
+#   Libint_LIBRARY - same as LIBRARIES
+#   Libint_MAX_AM_ERI - maximum angular momentum level of Libint libraries
+#
+#
+# Available components: shared static MAX_AM_ERI
+#
+# ::
+#
+#   shared - search for only shared library
+#   static - search for only static library
+#   [3, 10] - search for library with angular momentum >= this integer
+#
+#
+# Exported targets:
+#
+# ::
+#
+# If Libint is found, this module defines the following :prop_tgt:`IMPORTED`
+# targets. Target is shared _or_ static, so, for both, use separate, not
+# overlapping, installations. ::
+#
+#   Libint::libint - the main libint and libderiv libraries with headers & defs attached.
+#   Libint::int - the main libint library with header & defs attached.
+#   Libint::deriv - the main libderiv library with header & defs attached.
+#
+#
+# Suggested usage:
+#
+# ::
+#
+#   find_package(Libint)
+#   find_package(Libint 1.1.6 EXACT CONFIG REQUIRED COMPONENTS shared 6)
+#
+#
+# The following variables can be set to guide the search for this package:
+#
+# ::
+#
+#   Libint_DIR - CMake variable, set to directory containing this Config file
+#   CMAKE_PREFIX_PATH - CMake variable, set to root directory of this package
+#   PATH - environment variable, set to bin directory of this package
+#   CMAKE_DISABLE_FIND_PACKAGE_Libint - CMake variable, disables 
+#     find_package(Libint) when not REQUIRED, perhaps to force internal build
+
+@PACKAGE_INIT@
+
+set(PN Libint)
+set (_valid_components
+    static
+    shared
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+)
+
+# find includes
+unset(_temp_h CACHE)
+find_path(_temp_h
+          NAMES libint/libint.h
+          PATHS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@
+          NO_DEFAULT_PATH)
+if(_temp_h)
+    set(${PN}_INCLUDE_DIR "${_temp_h}")
+    set(${PN}_INCLUDE_DIRS ${${PN}_INCLUDE_DIR})
+else()
+    set(${PN}_FOUND 0)
+    if(NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "${PN}Config missing component: header (${PN}: ${_temp_h})")
+    endif()
+endif()
+
+# find library: shared, static, or whichever
+set(_hold_library_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+list(FIND ${PN}_FIND_COMPONENTS "shared" _seek_shared)
+list(FIND ${PN}_FIND_COMPONENTS "static" _seek_static)
+if(_seek_shared GREATER -1)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+elseif(_seek_static GREATER -1)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+unset(_temp_int CACHE)
+find_library(_temp_int
+             NAMES int
+             PATHS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@
+             NO_DEFAULT_PATH)
+unset(_temp_deriv CACHE)
+find_library(_temp_deriv
+             NAMES deriv
+             PATHS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@
+             NO_DEFAULT_PATH)
+if(_temp_int AND _temp_deriv)
+    set(${PN}_LIBRARY "${_temp_int} ${_temp_deriv}")
+    if(_seek_shared GREATER -1)
+        set(${PN}_shared_FOUND 1)
+    elseif(_seek_static GREATER -1)
+        set(${PN}_static_FOUND 1)
+    endif()
+else()
+    if(_seek_shared GREATER -1)
+        if(NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "${PN}Config missing component: shared libraries (int: ${_temp_int}, deriv: ${_temp_deriv})")
+        endif()
+    elseif(_seek_static GREATER -1)
+        if(NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "${PN}Config missing component: static libraries (int: ${_temp_int}, deriv: ${_temp_deriv})")
+        endif()
+    else()
+        set(${PN}_FOUND 0)
+        if(NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "${PN}Config missing component: libraries (int: ${_temp_int}, deriv: ${_temp_deriv})")
+        endif()
+    endif()
+endif()
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_hold_library_suffixes})
+set(${PN}_LIBRARIES ${${PN}_LIBRARY})
+
+# check AM component
+#   * Psi4 uses MAX_AM_ERI (formerly LIBINT_OPT_AM) for AM control
+#   * libint.h uses LIBINT_MAX_AM = MAX_AM_ERI + 1
+#   * libint.h uses LIBINT_OPT_AM = ceiling(LIBINT_MAX_AM / 2)
+file(READ ${${PN}_INCLUDE_DIR}/libint/libint.h _contents)
+string(REGEX MATCH "define LIBINT_MAX_AM (.|..)" DA_LINE ${_contents})
+math(EXPR ${PN}_MAX_AM_ERI ${CMAKE_MATCH_1}-1)
+foreach(_comp IN LISTS ${PN}_FIND_COMPONENTS)
+    list(FIND _valid_components ${_comp} _seek_am)
+    if(_seek_am GREATER 1)  # component is AM, not shared or static
+        # detected >= requested
+        if(NOT ${${PN}_MAX_AM_ERI} LESS ${_comp})
+            set(${PN}_${_comp}_FOUND 1)
+        else()
+            if(NOT CMAKE_REQUIRED_QUIET)
+                message(STATUS "${PN}Config missing component: requested AM ${_comp} > ${${PN}_MAX_AM_ERI} detected in ${${PN}_LIBRARY}")
+            endif()
+        endif()
+    endif()
+endforeach()
+set(${PN}_DEFINITIONS "USING_${PN};MAX_AM_ERI=${${PN}_MAX_AM_ERI}")
+
+check_required_components(${PN})
+
+#-----------------------------------------------------------------------------
+# Don't include targets if this file is being picked up by another
+# project which has already built this as a subproject
+#-----------------------------------------------------------------------------
+if(NOT TARGET ${PN}::int)
+    include("${CMAKE_CURRENT_LIST_DIR}/LibintintTargets.cmake")
+endif()
+if(NOT TARGET ${PN}::deriv)
+    include("${CMAKE_CURRENT_LIST_DIR}/LibintderivTargets.cmake")
+endif()
+if(NOT TARGET ${PN}::libint)
+    add_library(${PN}::libint UNKNOWN IMPORTED)
+    set_target_properties(${PN}::libint PROPERTIES
+        IMPORTED_LOCATION                 "${_temp_deriv}"
+        INTERFACE_INCLUDE_DIRECTORIES     "${${PN}_INCLUDE_DIRS}"
+        INTERFACE_COMPILE_DEFINITIONS     "${${PN}_DEFINITIONS}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+        INTERFACE_LINK_LIBRARIES          ${PN}::int)
+endif()

--- a/cmake/autocmake_safeguards.cmake
+++ b/cmake/autocmake_safeguards.cmake
@@ -1,0 +1,26 @@
+# Downloaded from
+#   https://github.com/coderefinery/autocmake/blob/master/modules/safeguards.cmake
+# * changed text of in-source message
+
+#.rst:
+#
+# Provides safeguards against in-source builds and bad build types.
+#
+# Variables used::
+#
+#   PROJECT_SOURCE_DIR
+#   PROJECT_BINARY_DIR
+#   CMAKE_BUILD_TYPE
+
+if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
+    message(FATAL_ERROR "In-source builds not allowed. Please run CMake from top directory and specify a build directory (e.g., cmake -H. -Bbuild).")
+endif()
+
+string(TOLOWER "${CMAKE_BUILD_TYPE}" cmake_build_type_tolower)
+string(TOUPPER "${CMAKE_BUILD_TYPE}" cmake_build_type_toupper)
+
+if(NOT cmake_build_type_tolower STREQUAL "debug" AND
+   NOT cmake_build_type_tolower STREQUAL "release" AND
+   NOT cmake_build_type_tolower STREQUAL "relwithdebinfo")
+    message(FATAL_ERROR "Unknown build type \"${CMAKE_BUILD_TYPE}\". Allowed values are Debug, Release, RelWithDebInfo (case-insensitive).")
+endif()

--- a/cmake/autocmake_static_library.cmake
+++ b/cmake/autocmake_static_library.cmake
@@ -1,0 +1,56 @@
+# Downloaded from
+#   https://github.com/PCMSolver/pcmsolver/blob/release/1.Y/cmake/custom/static_library.cmake
+# * suppressed STATIC_LIBRARY_ONLY
+# * moved option up
+# * corrected CXX block matches statements from C --> CXX compiler
+
+#.rst:
+#
+# Enables creation of static library.
+# If the shared library is created, make it as static as possible.
+#
+# Variables modified (provided the corresponding language is enabled)::
+#
+#   CMAKE_Fortran_FLAGS
+#   CMAKE_C_FLAGS
+#   CMAKE_CXX_FLAGS
+#
+# autocmake.cfg configuration::
+#
+#   docopt: --static Create only the static library [default: False].
+#   define: '-DSTATIC_LIBRARY_ONLY=%s' % arguments['--static']
+
+if(ENABLE_GENERIC)
+    if(DEFINED CMAKE_Fortran_COMPILER_ID)
+        if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -static-libgfortran")
+        endif()
+        if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -static-libgcc -static-intel")
+        endif()
+    endif()
+
+    if(DEFINED CMAKE_C_COMPILER_ID)
+        if(CMAKE_C_COMPILER_ID MATCHES GNU)
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc -fpic")
+        endif()
+        if(CMAKE_C_COMPILER_ID MATCHES Intel)
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc -static-intel -wd10237")
+        endif()
+        if(CMAKE_C_COMPILER_ID MATCHES Clang)
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic")
+        endif()
+    endif()
+
+    if(DEFINED CMAKE_CXX_COMPILER_ID)
+        if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc")
+        endif()
+        if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--as-needed -static-libstdc++ -static-libgcc -static-intel -wd10237")
+        endif()
+        if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
+        endif()
+    endif()
+endif()

--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -1,0 +1,156 @@
+###This file contains functions used throughout the Psi4 build.  Like source
+###code, the build system should be factored and common code extracted out into
+###functions/macros.  If you find repetitive code throughout the build scripts
+###this is the place to add it (make sure you document it too).
+
+#Macro for printing an option in a consistent manner
+#
+#Syntax: print_option(<option to print> <was specified>)
+#
+macro(print_option variable default)
+if(NOT DEFINED ${variable} OR "${${variable}}" STREQUAL "")
+    message(STATUS "Setting (unspecified) option ${variable}: ${default}")
+else()
+    message(STATUS "Setting option ${variable}: ${${variable}}")
+endif()
+endmacro()
+
+# Wraps an option with default ON/OFF. Adds nice messaging to option()
+#
+#Syntax: option_with_print(<option name> <description> <default value>)
+#
+macro(option_with_print variable msge default)
+   print_option(${variable} ${default})
+   option(${variable} ${msge} ${default})
+endmacro(option_with_print)
+
+#Wraps an option with a default other than ON/OFF and prints it
+#NOTE: Can't combine with above b/c CMake handles ON/OFF options specially
+#NOTE2: CMAKE_BUILD_TYPE (and other CMake variables) are always defined so need
+#       to further check for if they are the NULL string.  This is also why we
+#       need the force
+#
+#Syntax: option_with_default(<option name> <description> <default value>)
+#
+macro(option_with_default variable msge default)
+print_option(${variable} ${default})
+if(NOT DEFINED ${variable} OR "${${variable}}" STREQUAL "")
+   set(${variable} ${default} CACHE STRING ${msge} FORCE)
+endif()
+endmacro(option_with_default)
+
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+if(CMAKE_Fortran_COMPILER)
+    include(CheckFortranCompilerFlag)  # CMake >= 3.3, so local copy in cmake/
+endif()
+
+#The guts of the next two functions, use the wrappers please
+#
+#Syntax: add_C_or_CXX_flags(<True for C, False for CXX>)
+#
+# Note: resist adding -Werror to the check_X_compiler_flag calls,
+#   as (i) the flag for Intel is actually -diag-error warn, (ii)
+#   Intel ifort doesn't define -Werror, and (iii) passing it
+#   changes REQUIRED_DEFINITIONS.
+macro(add_C_or_CXX_flags is_C)
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+   set(CMAKE_REQUIRED_QUIET ON)
+   set(flags_to_try "${ARGN}")
+   foreach(flag_i IN LISTS flags_to_try ITEMS -brillig)
+      if(${flag_i} STREQUAL "-brillig")
+         message(WARNING "Option unfulfilled as none of ${flags_to_try} valid")
+         break()
+      endif()
+      unset(test_option CACHE)
+      if(${is_C} EQUAL 0)
+          CHECK_C_COMPILER_FLAG("${flag_i}" test_option)
+          set(description_to_print CMAKE_C_FLAGS)
+      elseif(${is_C} EQUAL 1)
+          CHECK_CXX_COMPILER_FLAG("${flag_i}" test_option)
+          set(description_to_print CMAKE_CXX_FLAGS)
+      elseif(${is_C} EQUAL 2)
+          CHECK_Fortran_COMPILER_FLAG("${flag_i}" test_option)
+          set(description_to_print CMAKE_Fortran_FLAGS)
+      endif()
+      set(msg_base "Performing Test ${description_to_print} [${flag_i}] -")
+      if(${test_option})
+        set(${description_to_print} "${${description_to_print}} ${flag_i}")
+        if(NOT CMAKE_REQUIRED_QUIET_SAVE)
+           message(STATUS  "${msg_base} Success, Appending")
+        endif()
+        break()
+      else()
+        if(NOT CMAKE_REQUIRED_QUIET_SAVE)
+           message(STATUS "${msg_base} Failed")
+        endif()
+      endif()
+   endforeach()
+   set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})  
+endmacro()
+
+
+
+#Checks if C flags are valid, if so adds them to CMAKE_C_FLAGS
+#Input should be a list of flags to try.  If two flags are to be tried together
+#enclose them in quotes, e.g. "-L/path/to/dir -lmylib" is tried as a single
+#flag, whereas "-L/path/to/dir" "-lmylib" is tried as two separate flags.
+#The first list item to succeed is added to CMAKE_C_FLAGS, then try loop
+#breaks. Warning issued if no flags in list succeed.
+#
+#
+#Syntax: add_C_flags(<flags to add>)
+#
+macro(add_C_flags)
+   add_C_or_CXX_flags(0 ${ARGN})
+endmacro()
+
+#Checks if CXX flags are valid, if so adds them to CMAKE_CXX_FLAGS
+#See add_C_flags for more info on syntax
+#
+#Syntax: add_CXX_flags(<flags to add>)
+#
+macro(add_CXX_flags)
+    add_C_or_CXX_flags(1 ${ARGN})
+endmacro()
+
+#Checks if Fortran flags are valid, if so adds them to CMAKE_Fortran_FLAGS
+#See add_C_flags for more info on syntax
+#
+#Syntax: add_Fortran_flags(<flags to add>)
+#
+macro(add_Fortran_flags)
+    add_C_or_CXX_flags(2 ${ARGN})
+endmacro()
+
+#Macro for adding flags common to both C and CXX, if the compiler supports them
+#
+#Syntax: add_flags(<flags to add>)
+#
+macro(add_flags FLAGS)
+    get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+    list(FIND languages "C" _index_c)
+    list(FIND languages "CXX" _index_cxx)
+    list(FIND languages "Fortran" _index_fortran)
+    if (${_index_c} GREATER -1)
+        add_C_flags(${FLAGS})
+    endif()
+    if (${_index_cxx} GREATER -1)
+        add_CXX_flags(${FLAGS})
+    endif()
+    if (${_index_fortran} GREATER -1)
+        add_Fortran_flags(${FLAGS})
+    endif()
+endmacro()
+
+#Defines an option that if enabled turns on some compiler flags
+#
+#Syntax: option_with_flags(<option> <description> <default value> <flags>)
+#
+macro(option_with_flags option msg default)
+    print_option(${option} ${default})
+    option(${option} ${msg} ${default})
+    if(${${option}})
+       add_flags("${ARGN}")
+    endif()
+endmacro()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,80 @@
+include(ExternalProject)
+include(GNUInstallDirs)
+
+# correcting for this repo being one off from Psi4 conventions
+math(EXPR MAX_AM_ERI "${MAX_AM_ERI}-1")
+
+ExternalProject_Add(libint_compiler
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin/libint
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DMAX_AM_ERI=${MAX_AM_ERI}
+    CMAKE_CACHE_ARGS -DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
+                     -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} 
+    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
+    DESTDIR=${CMAKE_BINARY_DIR}/stage)
+
+ExternalProject_Add(libint_library
+    DEPENDS libint_compiler
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libint
+    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/libint-src
+    # download generalized to generating source by running libint_compiler
+    DOWNLOAD_COMMAND ${STAGED_INSTALL_PREFIX}/bin/libint_compiler
+    LOG_DOWNLOAD 1
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+               -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+               -DMAX_AM_ERI=${MAX_AM_ERI}
+               -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+               -DBUILD_FPIC=${BUILD_FPIC}
+               -DLIBC_INTERJECT=${LIBC_INTERJECT}
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} 
+                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} 
+    BINARY_DIR ${CMAKE_BINARY_DIR}/libint-src
+    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
+    DESTDIR=${CMAKE_BINARY_DIR}/stage)
+
+ExternalProject_Add(libderiv_compiler
+    DEPENDS libint_library
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin/libderiv
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DMAX_AM_ERI=${MAX_AM_ERI}
+               -DLibintint_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/Libint
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} 
+    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
+    DESTDIR=${CMAKE_BINARY_DIR}/stage)
+
+ExternalProject_Add(libderiv_library
+    DEPENDS libderiv_compiler
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libderiv
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+               -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+               -DMAX_AM_ERI=${MAX_AM_ERI}
+               -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+               -DBUILD_FPIC=${BUILD_FPIC}
+               -DLIBC_INTERJECT=${LIBC_INTERJECT}
+               -DLibintint_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/Libint
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} 
+                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} 
+    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/libderiv-src
+    DOWNLOAD_COMMAND ${STAGED_INSTALL_PREFIX}/bin/libderiv_compiler
+    LOG_DOWNLOAD 1
+    BINARY_DIR ${CMAKE_BINARY_DIR}/libderiv-src
+    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
+    DESTDIR=${CMAKE_BINARY_DIR}/stage)
+
+# Note that libint_library and libderiv_library could build in parallel
+#   if (1) the code generation step of libint_library was moved to the end
+#   of libint_compiler and (2) libderiv_compiler was given a way to detect
+#   the generated files. That code generation step produces libint.h and
+#   that's what libderiv_compiler is waiting for.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,7 @@ ExternalProject_Add(libderiv_library
                -DBUILD_FPIC=${BUILD_FPIC}
                -DLIBC_INTERJECT=${LIBC_INTERJECT}
                -DLibintint_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/Libint
+               -DMERGE_LIBDERIV_INCLUDEDIR=${MERGE_LIBDERIV_INCLUDEDIR}
     CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} 
                      -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} 
     DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/libderiv-src

--- a/src/bin/libderiv/CMakeLists.txt
+++ b/src/bin/libderiv/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.0)
+project(libderiv_compiler LANGUAGES C)
+
+# <<<  Build  >>>
+
+# create dummy header file
+configure_file(../libint_config.h.cmake.in libint_config.h @ONLY)
+
+set(COMPILER_SRC build_libderiv.c
+                 emit_d1hrr_build_macro.c
+                 emit_deriv1_managers.c
+                 emit_deriv_build_macro.c
+                 emit_d1hrr_build.c
+                 emit_deriv12_managers.c
+                 emit_deriv_build.c
+                 mem_man.c
+)
+add_executable(libderiv_compiler ${COMPILER_SRC})
+
+target_include_directories(libderiv_compiler PRIVATE ../
+                                                     ${PROJECT_BINARY_DIR})
+
+math(EXPR LIBDERIV_OPT_AM1 ${MAX_AM_ERI}-1)  # A.M. level for 1st derivative ERIs
+math(EXPR LIBINT_MAX_AM ${MAX_AM_ERI}+1)
+math(EXPR LIBINT_OPT_AM "${MAX_AM_ERI}/2 + ${MAX_AM_ERI}%2")
+target_compile_definitions(libderiv_compiler
+    PRIVATE -DLIBDERIV_MAX_AM1=${MAX_AM_ERI}
+            -DLIBDERIV_MAX_AM12=${LIBDERIV_OPT_AM1}
+            -DLIBINT_MAX_AM=${LIBINT_MAX_AM}
+            -DLIBINT_OPT_AM=${LIBINT_OPT_AM})
+
+# acquire libint.h
+find_package(Libintint CONFIG REQUIRED)
+target_include_directories(libderiv_compiler PRIVATE
+    $<TARGET_PROPERTY:Libint::int,INTERFACE_INCLUDE_DIRECTORIES>)
+
+# <<<  Install  >>>
+
+install(TARGETS libderiv_compiler
+        RUNTIME DESTINATION bin)

--- a/src/bin/libint/CMakeLists.txt
+++ b/src/bin/libint/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.0)
+project(libint_compiler LANGUAGES C)
+
+# <<<  Build  >>>
+
+# create dummy header file
+configure_file(../libint_config.h.cmake.in libint_config.h @ONLY)
+
+set(COMPILER_SRC build_libint.c
+                 emit_hrr_build.c
+                 emit_hrr_build_macro.c
+                 emit_order.c
+                 emit_vrr_build.c
+                 emit_vrr_build_macro.c
+                 mem_man.c
+)
+add_executable(libint_compiler ${COMPILER_SRC})
+
+# link -lm only if necessary
+find_package(StandardMathLibraryC)
+target_link_libraries(libint_compiler ${STANDARD_MATH_LIBRARY})
+target_include_directories(libint_compiler PRIVATE ../
+                                                   ${PROJECT_BINARY_DIR})
+
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "PGI")
+  set_target_properties(libint_compiler PROPERTIES COMPILE_FLAGS "-c99")
+else()
+  set_target_properties(libint_compiler PROPERTIES COMPILE_FLAGS "-std=c99")
+endif()
+
+math(EXPR LIBINT_MAX_AM ${MAX_AM_ERI}+1)
+math(EXPR LIBINT_OPT_AM "${MAX_AM_ERI}/2 + ${MAX_AM_ERI}%2")
+target_compile_definitions(libint_compiler
+    PRIVATE -DLIBINT_MAX_AM=${LIBINT_MAX_AM}
+            -DLIBINT_OPT_AM=${LIBINT_OPT_AM}
+            -DLIBINT_MAX_CLASS_SIZE=300
+            -DLONG_DOUBLE=0)
+
+# <<<  Install  >>>
+
+install(TARGETS libint_compiler
+        RUNTIME DESTINATION bin)

--- a/src/lib/libderiv/CMakeLists.txt
+++ b/src/lib/libderiv/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.0)
+project(Libintderiv LANGUAGES C CXX)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(NS Libint)
+set(PN ${PROJECT_NAME})
+
+# <<<  Build  >>>
+
+file(GLOB sources_list "${CMAKE_BINARY_DIR}/*.cc" vrr_build.c)
+
+    # STATIC/SHARED on below governed by BUILD_SHARED_LIBS
+add_library(deriv ${sources_list})
+target_include_directories(deriv PRIVATE ${CMAKE_BINARY_DIR})
+    # acquire libint.h and libint library
+find_package(Libintint CONFIG REQUIRED)
+target_link_libraries(deriv PRIVATE Libint::int)
+
+set_target_properties(deriv PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC})
+if(${BUILD_SHARED_LIBS})
+    target_link_libraries(deriv PRIVATE ${LIBC_INTERJECT})
+endif()
+
+# <<<  Install  >>>
+
+install(FILES ${CMAKE_BINARY_DIR}/libderiv.h
+              ${CMAKE_BINARY_DIR}/d1hrr_header.h
+              ${CMAKE_BINARY_DIR}/deriv_header.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libint)
+install(TARGETS deriv
+        EXPORT "${PN}Targets"
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# <<<  Export Interface  >>>
+
+target_compile_definitions(deriv INTERFACE USING_${NS}
+                                           MAX_AM_ERI=${MAX_AM_ERI})
+target_include_directories(deriv INTERFACE
+                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+# <<<  Export Config  >>>
+
+    # explicit "share" not "DATADIR" for CMake search path
+set(CMAKECONFIG_INSTALL_DIR "share/cmake/${NS}")
+configure_package_config_file(${PN}Config.cmake.in
+                              "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
+                              INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
+        DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+install(EXPORT "${PN}Targets"
+        NAMESPACE "${NS}::"
+        DESTINATION ${CMAKECONFIG_INSTALL_DIR})

--- a/src/lib/libderiv/CMakeLists.txt
+++ b/src/lib/libderiv/CMakeLists.txt
@@ -25,10 +25,18 @@ endif()
 
 # <<<  Install  >>>
 
-install(FILES ${CMAKE_BINARY_DIR}/libderiv.h
-              ${CMAKE_BINARY_DIR}/d1hrr_header.h
-              ${CMAKE_BINARY_DIR}/deriv_header.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libint)
+if(${MERGE_LIBDERIV_INCLUDEDIR})
+    install(FILES ${CMAKE_BINARY_DIR}/libderiv.h
+                  ${CMAKE_BINARY_DIR}/d1hrr_header.h
+                  ${CMAKE_BINARY_DIR}/deriv_header.h
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libint)
+else()
+    install(FILES ${CMAKE_BINARY_DIR}/libderiv.h
+                  ${CMAKE_BINARY_DIR}/d1hrr_header.h
+                  ${CMAKE_BINARY_DIR}/deriv_header.h
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libderiv)
+endif()
+
 install(TARGETS deriv
         EXPORT "${PN}Targets"
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -36,8 +44,9 @@ install(TARGETS deriv
 
 # <<<  Export Interface  >>>
 
+math(EXPR _max_am "${MAX_AM_ERI}+1")
 target_compile_definitions(deriv INTERFACE USING_${NS}
-                                           MAX_AM_ERI=${MAX_AM_ERI})
+                                           MAX_AM_ERI=${_max_am})
 target_include_directories(deriv INTERFACE
                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 

--- a/src/lib/libderiv/LibintderivConfig.cmake.in
+++ b/src/lib/libderiv/LibintderivConfig.cmake.in
@@ -1,0 +1,7 @@
+#-----------------------------------------------------------------------------
+# Don't include targets if this file is being picked up by another
+# project which has already built this as a subproject
+#-----------------------------------------------------------------------------
+if(NOT TARGET Libint::deriv)
+    include("${CMAKE_CURRENT_LIST_DIR}/LibintderivTargets.cmake")
+endif()

--- a/src/lib/libint/CMakeLists.txt
+++ b/src/lib/libint/CMakeLists.txt
@@ -33,8 +33,9 @@ install(TARGETS int
 
 # <<<  Export Interface  >>>
 
+math(EXPR _max_am "${MAX_AM_ERI}+1")
 target_compile_definitions(int INTERFACE USING_${NS}
-                                         MAX_AM_ERI=${MAX_AM_ERI})
+                                         MAX_AM_ERI=${_max_am})
 target_include_directories(int INTERFACE
                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 

--- a/src/lib/libint/CMakeLists.txt
+++ b/src/lib/libint/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.0)
+project(Libintint LANGUAGES C CXX)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(NS Libint)
+set(PN ${PROJECT_NAME})
+
+# <<<  Build  >>>
+
+file(GLOB sources_list "${CMAKE_BINARY_DIR}/*.cc" vrr_build.c)
+
+    # STATIC/SHARED on below governed by BUILD_SHARED_LIBS
+add_library(int ${sources_list})
+target_include_directories(int PRIVATE ${CMAKE_BINARY_DIR})
+
+set_target_properties(int PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC})
+if(${BUILD_SHARED_LIBS})
+    target_link_libraries(int PRIVATE ${LIBC_INTERJECT})
+endif()
+
+# <<<  Install  >>>
+
+install(FILES ${CMAKE_BINARY_DIR}/libint.h
+              ${CMAKE_BINARY_DIR}/hrr_header.h
+              ${CMAKE_BINARY_DIR}/vrr_header.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libint)
+install(TARGETS int
+        EXPORT "${PN}Targets"
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# <<<  Export Interface  >>>
+
+target_compile_definitions(int INTERFACE USING_${NS}
+                                         MAX_AM_ERI=${MAX_AM_ERI})
+target_include_directories(int INTERFACE
+                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+# <<<  Export Config  >>>
+
+    # explicit "share" not "DATADIR" for CMake search path
+set(CMAKECONFIG_INSTALL_DIR "share/cmake/${NS}")
+configure_package_config_file(${PN}Config.cmake.in
+                              "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
+                              INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
+        DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+install(EXPORT "${PN}Targets"
+        NAMESPACE "${NS}::"
+        DESTINATION ${CMAKECONFIG_INSTALL_DIR})

--- a/src/lib/libint/LibintintConfig.cmake.in
+++ b/src/lib/libint/LibintintConfig.cmake.in
@@ -1,0 +1,7 @@
+#-----------------------------------------------------------------------------
+# Don't include targets if this file is being picked up by another
+# project which has already built this as a subproject
+#-----------------------------------------------------------------------------
+if(NOT TARGET Libint::int)
+    include("${CMAKE_CURRENT_LIST_DIR}/LibintintTargets.cmake")
+endif()


### PR DESCRIPTION
* MAX/OPT/NEW_AM keywords seems to be the greatest divergence between upstream and Psi4 flavors of Libint1. I won't say that the current scheme is the simplest, but it does reproduce again the AM table in README_CMake.

* Seems to build just fine. There were so few changes to the CMake itself that I'm not too worried about extensively re-testing the build.

* All the generated files had "GNU Lesser General", not "GNU General", so that looks good.

* Built it in Psi4 (PR to Psi4 on Libint build changes not yet submitted) just fine.

* No errors in at least the first 200 Psi4 test cases.

So, look this over and see if you like it, please, and let me know anything you'd like changed. No rush to incorporate it – in fact early next week is when I'd probably look to getting all the Libint/Psi4 finalized.

I don't mind doing CMake for Libint2 — it's just never been pressing. Dare I hope Boost is only needed for the generator build, not as a runtime library?