### PR TITLE
Make Libint buildable with Ninja

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,9 @@ ExternalProject_Add(libint_compiler
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                -DMAX_AM_ERI=${MAX_AM_ERI}
     CMAKE_CACHE_ARGS -DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
-                     -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} 
-    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-    DESTDIR=${CMAKE_BINARY_DIR}/stage)
+                     -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+    INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install
+    )
 
 ExternalProject_Add(libint_library
     DEPENDS libint_compiler
@@ -32,11 +32,11 @@ ExternalProject_Add(libint_library
                -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                -DBUILD_FPIC=${BUILD_FPIC}
                -DLIBC_INTERJECT=${LIBC_INTERJECT}
-    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} 
-                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} 
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
     BINARY_DIR ${CMAKE_BINARY_DIR}/libint-src
-    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-    DESTDIR=${CMAKE_BINARY_DIR}/stage)
+    INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install
+    )
 
 ExternalProject_Add(libderiv_compiler
     DEPENDS libint_library
@@ -46,9 +46,9 @@ ExternalProject_Add(libderiv_compiler
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                -DMAX_AM_ERI=${MAX_AM_ERI}
                -DLibintint_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/Libint
-    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} 
-    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-    DESTDIR=${CMAKE_BINARY_DIR}/stage)
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+    INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install
+    )
 
 ExternalProject_Add(libderiv_library
     DEPENDS libderiv_compiler
@@ -65,14 +65,14 @@ ExternalProject_Add(libderiv_library
                -DLIBC_INTERJECT=${LIBC_INTERJECT}
                -DLibintint_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/Libint
                -DMERGE_LIBDERIV_INCLUDEDIR=${MERGE_LIBDERIV_INCLUDEDIR}
-    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} 
-                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} 
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
     DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/libderiv-src
     DOWNLOAD_COMMAND ${STAGED_INSTALL_PREFIX}/bin/libderiv_compiler
     LOG_DOWNLOAD 1
     BINARY_DIR ${CMAKE_BINARY_DIR}/libderiv-src
-    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
-    DESTDIR=${CMAKE_BINARY_DIR}/stage)
+    INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install
+    )
 
 # Note that libint_library and libderiv_library could build in parallel
 #   if (1) the code generation step of libint_library was moved to the end


### PR DESCRIPTION
DESTDIR=${CMAKE_BINARY_DIR}/stage was prepended to ${CMAKE_MAKE_PROGRAM} install
appearing in all instances of INSTALL_COMMAND