### PR TITLE
corrected typo in CITATION

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -16,7 +16,7 @@ The literature citation for the present version in bibtex format is:
 
 @Misc{Libint2,
   author = "E.~F.~Valeev",
-  title = “Libint: A library for the evaluation of molecular integrals of many-body operators over Gaussian functions",
+  title = "Libint: A library for the evaluation of molecular integrals of many-body operators over Gaussian functions",
   howpublished = "http://libint.valeyev.net/",
   note = "version 2.4.2",
   year =         2017


### PR DESCRIPTION
There was a non-ASCII character in CITATION (**“**), which could throw an error in LaTeX if copied and pasted. This PR changes this single character. I also made sure that the end result compiles correctly in LaTeX.