### PR TITLE
Missing using statements and include

### DIFF
--- a/include/libint2/util/any.h
+++ b/include/libint2/util/any.h
@@ -27,11 +27,18 @@
 #include <string>
 #include <cassert>
 
+// Include C++17 any header
+#if __cplusplus >= 201703L
+#include <any>
+#endif
+
 namespace libint2 {
 
 // use C++17 std::any, if available
 #if __cplusplus >= 201703L
 using std::any;
+using std::any_cast;
+using std::bad_any_cast;
 #else
 
 namespace detail {


### PR DESCRIPTION
This PR adds missing using statements and includes such that the header exposes the same symbols irregardless whether the C++ standard library or the fallback implementation are used.