### PR TITLE
Port to Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include(autocmake_safeguards)
 include(autocmake_static_library)
 
 ################################# Main Project #################################
-set(STAGED_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/staged)
+set(STAGED_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/stage)
 
 add_subdirectory(src)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include(autocmake_safeguards)
 include(autocmake_static_library)
 
 ################################# Main Project #################################
-set(STAGED_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/stage${CMAKE_INSTALL_PREFIX})
+set(STAGED_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/staged)
 
 add_subdirectory(src)
 include(GNUInstallDirs)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ before_build:
   - mkdir build && cd build
   - cmake -A %PLATFORM%
           -DCMAKE_BUILD_TYPE=%CONFIGURATION%
+          -DMAX_AM_ERI=8
           -DENABLE_XHOST=OFF
           -DCMAKE_C_FLAGS="/wd4101 /wd4996"
           -DCMAKE_CXX_FLAGS="/wd4101 /wd4996"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ before_build:
   - mkdir build && cd build
   - cmake -A %PLATFORM%
           -DCMAKE_BUILD_TYPE=%CONFIGURATION%
-          -DMAX_AM_ERI=8
           -DENABLE_XHOST=OFF
           -DCMAKE_C_FLAGS="/wd4101 /wd4996"
           -DCMAKE_CXX_FLAGS="/wd4101 /wd4996"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,27 @@
-image: Visual Studio 2017
-clone_depth: 5
+clone_depth: 1
+platform: x64
 
-install:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+image:
+  - Visual Studio 2015
+  - Visual Studio 2017
+
+configuration:
+  - Debug
 
 before_build:
   - mkdir build && cd build
-  - cmake -A x64
+  - cmake -A %PLATFORM%
+          -DCMAKE_BUILD_TYPE=%CONFIGURATION%
+          -DENABLE_XHOST=OFF
           -DCMAKE_C_FLAGS="/wd4101 /wd4996"
           -DCMAKE_CXX_FLAGS="/wd4101 /wd4996"
           ..
 
 build_script:
   - cmake --build .
+          --config %CONFIGURATION%
 
 after_build:
-  - cmake --build . --target install
+  - cmake --build .
+          --config %CONFIGURATION%
+          --target install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+image: Visual Studio 2017
+clone_depth: 5
+
+install:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+before_build:
+  - mkdir build && cd build
+  - cmake -A x64
+          -DCMAKE_C_FLAGS="/wd4101 /wd4996"
+          -DCMAKE_CXX_FLAGS="/wd4101 /wd4996"
+          ..
+
+build_script:
+  - cmake --build .
+
+after_build:
+  - cmake --build . --target install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,9 +10,8 @@ ExternalProject_Add(libint_compiler
                -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DMAX_AM_ERI=${MAX_AM_ERI}
-    )
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS})
 
 ExternalProject_Add(libint_library
     DEPENDS libint_compiler
@@ -25,16 +24,15 @@ ExternalProject_Add(libint_library
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-               -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                -DMAX_AM_ERI=${MAX_AM_ERI}
                -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                -DBUILD_FPIC=${BUILD_FPIC}
                -DLIBC_INTERJECT=${LIBC_INTERJECT}
-    )
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS})
 
 ExternalProject_Add(libderiv_compiler
     DEPENDS libint_library
@@ -42,10 +40,9 @@ ExternalProject_Add(libderiv_compiler
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DMAX_AM_ERI=${MAX_AM_ERI}
                -DLibintint_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/Libint
-    )
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS})
 
 ExternalProject_Add(libderiv_library
     DEPENDS libderiv_compiler
@@ -58,9 +55,7 @@ ExternalProject_Add(libderiv_library
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-               -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                -DMAX_AM_ERI=${MAX_AM_ERI}
@@ -69,7 +64,8 @@ ExternalProject_Add(libderiv_library
                -DLIBC_INTERJECT=${LIBC_INTERJECT}
                -DLibintint_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/Libint
                -DMERGE_LIBDERIV_INCLUDEDIR=${MERGE_LIBDERIV_INCLUDEDIR}
-    )
+    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS})
 
 # Note that libint_library and libderiv_library could build in parallel
 #   if (1) the code generation step of libint_library was moved to the end

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,13 +6,12 @@ math(EXPR MAX_AM_ERI "${MAX_AM_ERI}-1")
 
 ExternalProject_Add(libint_compiler
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin/libint
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    CMAKE_ARGS -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+               -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DMAX_AM_ERI=${MAX_AM_ERI}
-    CMAKE_CACHE_ARGS -DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
-                     -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-    INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install
     )
 
 ExternalProject_Add(libint_library
@@ -22,41 +21,46 @@ ExternalProject_Add(libint_library
     # download generalized to generating source by running libint_compiler
     DOWNLOAD_COMMAND ${STAGED_INSTALL_PREFIX}/bin/libint_compiler
     LOG_DOWNLOAD 1
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    BINARY_DIR ${CMAKE_BINARY_DIR}/libint-src
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                -DMAX_AM_ERI=${MAX_AM_ERI}
                -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                -DBUILD_FPIC=${BUILD_FPIC}
                -DLIBC_INTERJECT=${LIBC_INTERJECT}
-    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-    BINARY_DIR ${CMAKE_BINARY_DIR}/libint-src
-    INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install
     )
 
 ExternalProject_Add(libderiv_compiler
     DEPENDS libint_library
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin/libderiv
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DMAX_AM_ERI=${MAX_AM_ERI}
                -DLibintint_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/Libint
-    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-    INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install
     )
 
 ExternalProject_Add(libderiv_library
     DEPENDS libderiv_compiler
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/libderiv
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/libderiv-src
+    # download generalized to generating source by running libderiv_compiler
+    DOWNLOAD_COMMAND ${STAGED_INSTALL_PREFIX}/bin/libderiv_compiler
+    LOG_DOWNLOAD 1
+    BINARY_DIR ${CMAKE_BINARY_DIR}/libderiv-src
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                -DMAX_AM_ERI=${MAX_AM_ERI}
@@ -65,13 +69,6 @@ ExternalProject_Add(libderiv_library
                -DLIBC_INTERJECT=${LIBC_INTERJECT}
                -DLibintint_DIR=${STAGED_INSTALL_PREFIX}/share/cmake/Libint
                -DMERGE_LIBDERIV_INCLUDEDIR=${MERGE_LIBDERIV_INCLUDEDIR}
-    CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
-                     -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/libderiv-src
-    DOWNLOAD_COMMAND ${STAGED_INSTALL_PREFIX}/bin/libderiv_compiler
-    LOG_DOWNLOAD 1
-    BINARY_DIR ${CMAKE_BINARY_DIR}/libderiv-src
-    INSTALL_COMMAND DESTDIR=${CMAKE_BINARY_DIR}/stage ${CMAKE_MAKE_PROGRAM} install
     )
 
 # Note that libint_library and libderiv_library could build in parallel

--- a/src/bin/libderiv/build_libderiv.c
+++ b/src/bin/libderiv/build_libderiv.c
@@ -58,11 +58,11 @@ int main()
   /*-------------------------------
     Initialize files and libraries
    -------------------------------*/
-  outfile = fopen("./output.dat", "w");
-  d1hrr_header = fopen("./d1hrr_header.h","w");
-  deriv_header = fopen("./deriv_header.h","w");
-  libderiv_header = fopen("./libderiv.h","w");
-  init_code = fopen("./init_libderiv.cc","w");
+  outfile = fopen("output.dat", "w");
+  d1hrr_header = fopen("d1hrr_header.h","w");
+  deriv_header = fopen("deriv_header.h","w");
+  libderiv_header = fopen("libderiv.h","w");
+  init_code = fopen("init_libderiv.cc","w");
   copyright(d1hrr_header);
   copyright(deriv_header);
   copyright(libderiv_header);
@@ -129,7 +129,7 @@ int main()
 
   /* Setting up init_libderiv.c, header.h */
   fprintf(init_code,"#include <stdlib.h>\n");
-  fprintf(init_code,"#include <strings.h>\n");
+  fprintf(init_code,"#include <string.h>\n");
   fprintf(init_code,"#include <libint/libint.h>\n");
   fprintf(init_code,"#include \"libderiv.h\"\n");
   fprintf(init_code,"#include \"d1hrr_header.h\"\n\n");
@@ -179,7 +179,7 @@ int main()
   fprintf(init_code,"  libderiv->int_stack = (double *) malloc(libderiv1_stack_size[max_am]*sizeof(double));\n");
   fprintf(init_code,"  memory += libderiv1_stack_size[max_am];\n");
   fprintf(init_code,"  libderiv->zero_stack = (double *) malloc(max_cart_class_size*sizeof(double));\n");
-  fprintf(init_code,"  bzero((char *)libderiv->zero_stack,max_cart_class_size*sizeof(double));\n");
+  fprintf(init_code,"  memset((char *)libderiv->zero_stack,0,max_cart_class_size*sizeof(double));\n");
   fprintf(init_code,"  memory += max_cart_class_size;\n");
   fprintf(init_code,"  libderiv->PrimQuartet = (prim_data *) malloc(max_num_prim_quartets*sizeof(prim_data));\n");
   fprintf(init_code,"  memory += max_num_prim_quartets*sizeof(prim_data)/sizeof(double);\n");
@@ -205,7 +205,7 @@ int main()
   fprintf(init_code,"  libderiv->int_stack = (double *) malloc(libderiv12_stack_size[max_am]*sizeof(double));\n");
   fprintf(init_code,"  memory += libderiv12_stack_size[max_am];\n");
   fprintf(init_code,"  libderiv->zero_stack = (double *) malloc(max_cart_class_size*sizeof(double));\n");
-  fprintf(init_code,"  bzero((char *)libderiv->zero_stack,max_cart_class_size*sizeof(double));\n");
+  fprintf(init_code,"  memset((char *)libderiv->zero_stack,0,max_cart_class_size*sizeof(double));\n");
   fprintf(init_code,"  memory += max_cart_class_size;\n");
   fprintf(init_code,"  libderiv->PrimQuartet = (prim_data *) malloc(max_num_prim_quartets*sizeof(prim_data));\n");
   fprintf(init_code,"  memory += max_num_prim_quartets*sizeof(prim_data)/sizeof(double);\n");

--- a/src/bin/libint/CMakeLists.txt
+++ b/src/bin/libint/CMakeLists.txt
@@ -28,6 +28,11 @@ else()
   set_target_properties(libint_compiler PROPERTIES COMPILE_FLAGS "-std=c99")
 endif()
 
+if(MSVC)
+    # Increase stack size from 1 MB to 4 MB
+    set_target_properties(libint_compiler PROPERTIES LINK_FLAGS "/STACK:4194304")
+endif(MSVC)
+
 math(EXPR LIBINT_MAX_AM ${MAX_AM_ERI}+1)
 math(EXPR LIBINT_OPT_AM "${MAX_AM_ERI}/2 + ${MAX_AM_ERI}%2")
 target_compile_definitions(libint_compiler

--- a/src/bin/libint/build_libint.c
+++ b/src/bin/libint/build_libint.c
@@ -80,11 +80,11 @@ int main()
   /*-------------------------------
     Initialize files and libraries
    -------------------------------*/
-  outfile = fopen("./output.dat", "w");
-  vrr_header = fopen("./vrr_header.h","w");
-  hrr_header = fopen("./hrr_header.h","w");
-  libint_header = fopen("./libint.h","w");
-  init_code = fopen("./init_libint.cc","w");
+  outfile = fopen("output.dat", "w");
+  vrr_header = fopen("vrr_header.h","w");
+  hrr_header = fopen("hrr_header.h","w");
+  libint_header = fopen("libint.h","w");
+  init_code = fopen("init_libint.cc","w");
   copyright(vrr_header);
   copyright(hrr_header);
   copyright(libint_header);


### PR DESCRIPTION
This is part of *Psi4* porting to Windows (psi4/psi4#933):

- [x] Remove hard-coded path separators
- [x] Replace `bzero` with `memset`
- [x] Remove explicit call to `make` from CMake scripts
- [x] Add Appveyor configuration to compile and tests on Windows (https://ci.appveyor.com/project/raimis/libint). Appveyor has to be activated on the repository to work (https://www.appveyor.com/docs/).

