### PR TITLE
Fix version in CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_policy(SET CMP0048 NEW)  # project_VERSION* variables populated from project(... VERSION x.x.x) string
 
 project(Libint
-        VERSION 1.2.0
+        VERSION 1.2.1
         LANGUAGES C CXX)
 set(Libint_AUTHORS      "Edward F. Valeev and Justin T. Fermann")
 set(Libint_DESCRIPTION  "Library for the evaluation of molecular integrals of two-body operators over Gaussian functions")


### PR DESCRIPTION
This is part of Psi4 porting to Windows (https://github.com/psi4/psi4/issues/933).

- [x] Update version in `CMakeLists.txt` according to 29a6a6df4cd1242c54b5651fc0ac6dd563edf7c0