### PR TITLE
add pkgconfig file to cmake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 option_with_print(ENABLE_GENERIC "Enable mostly static linking in shared library" OFF)
 option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON
                     "-xHost" "-march=native")
-option_with_print(MERGE_LIBDERIV_INCLUDEDIR "Install libderiv headers to libint namespace. Psi4 wants ON" OFF)
+option_with_print(MERGE_LIBDERIV_INCLUDEDIR "Install libderiv headers to libint namespace. Psi4 1.1-1.3 wants ON" OFF)
 
 ######################### Process & Validate Options ###########################
 include(autocmake_safeguards)
@@ -37,6 +37,8 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 set(PN ${PROJECT_NAME})
+
+configure_file(cmake/libint.pc.in libint.pc @ONLY)
 
 # <<<  Install  >>>
 
@@ -60,3 +62,6 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
         DESTINATION ${CMAKECONFIG_INSTALL_DIR})
+
+install(FILES ${PROJECT_BINARY_DIR}/libint.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)

--- a/cmake/libint.pc.in
+++ b/cmake/libint.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: libint
+Description: a library for the evaluation of molecular integrals of many-body operators over Gaussian functions
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lderiv -lint
+Cflags: -I${includedir} -I${includedir}/libint -I${includedir}/libderiv


### PR DESCRIPTION
A packager wanted this (https://github.com/psi4/psi4/issues/1589) so that a CMake-built libint can be detected by both cmake and libtool downstream buildsystems. The CMake `LibintConfig.cmake` and friends are too involved to be imitated by libtool.

I constructed the `.pc` file by analogy to Libxc https://gitlab.com/libxc/libxc/blob/master/cmake/libxc.pc.in and https://gitlab.com/libxc/libxc/blob/master/build/libxc.pc.in . It builds and looks like the below, but I haven't tried out its consumption in a downstream libtool build.

```
>>> cat install-am4/lib64/pkgconfig/libint.pc 
prefix=/home/psilocaluser/gits/libint/install-am4
exec_prefix=/home/psilocaluser/gits/libint/install-am4
libdir=/home/psilocaluser/gits/libint/install-am4/lib64
includedir=/home/psilocaluser/gits/libint/install-am4/include

Name: libint
Description: a library for the evaluation of molecular integrals of many-body operators over Gaussian functions
Version: 1.2.1
Libs: -L${libdir} -lderiv -lint
Cflags: -I${includedir} -I${includedir}/libint -I${includedir}/libderiv
```