### PR TITLE
Produce static (PIC) and shared versions of the int2 library in the cmake project

### DIFF
--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -195,7 +195,6 @@ endif()
         # INCLUDES DESTINATION "${LIBINT2_INSTALL_INCLUDEDIR}"
        )
 
-
 add_subdirectory(include)
 
 # install basis set library
@@ -209,7 +208,7 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/lib/basis
 if (LIBINT_HAS_EIGEN)
   add_library(cxx INTERFACE)
   target_compile_features(cxx INTERFACE "cxx_std_11")
-  if (TARGET int2_static)
+  if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
     target_link_libraries(cxx INTERFACE int2_static Eigen)
   else()
     target_link_libraries(cxx INTERFACE int2 Eigen)
@@ -237,9 +236,9 @@ enable_testing(true)
 add_custom_target(check USES_TERMINAL COMMAND ${CMAKE_CTEST_COMMAND} -V)
 
 add_executable(eritest EXCLUDE_FROM_ALL tests/eri/test.cc)
-if (TARGET int2_static)
+if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
     target_link_libraries(eritest int2_static)
-  else ()
+else ()
     target_link_libraries(eritest int2)
 endif()
 target_include_directories(eritest PRIVATE ${CMAKE_SOURCE_DIR}/tests/eri)
@@ -372,7 +371,9 @@ if (ENABLE_FORTRAN)
 
     # tests
     add_executable(fortran_example EXCLUDE_FROM_ALL fortran/fortran_example.F90)
-    target_link_libraries(fortran_example libint_f int2_static)
+    if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
+      target_link_libraries(fortran_example libint_f int2_static)
+    endif()
     add_test(fortran_example/build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target fortran_example)
     set_tests_properties(fortran_example/build PROPERTIES FIXTURES_SETUP FORTRAN_EXAMPLE_EXEC)
     add_test(NAME fortran_example/run

--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -145,7 +145,6 @@ endforeach()
 add_library(int2_obj OBJECT ${LIB_CXX_SRC})
 target_include_directories(int2_obj PRIVATE include ${PROJECT_BINARY_DIR}/include)
 # Compile static library with position independent code
-set_target_properties(int2_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_compile_definitions(int2_obj PRIVATE __COMPILING_LIBINT2)
 target_compile_features(int2_obj PUBLIC "cxx_std_11")
@@ -157,32 +156,46 @@ if (NOT CMAKE_CXX_EXTENSIONS)
 endif(NOT CMAKE_CXX_EXTENSIONS)
 
 # shared and static libraries built from the same object files
-add_library(int2 SHARED $<TARGET_OBJECTS:int2_obj>)
-add_library(int2_static STATIC $<TARGET_OBJECTS:int2_obj>)
-
-target_include_directories(int2 INTERFACE
+if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
+  set_target_properties(int2_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  add_library(int2 SHARED $<TARGET_OBJECTS:int2_obj>)
+  set_target_properties(int2 PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  add_library(int2_static STATIC $<TARGET_OBJECTS:int2_obj>)
+  target_include_directories(int2_static INTERFACE
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/libint2>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}>
         )
-
-target_include_directories(int2_static INTERFACE
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/libint2>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}>
-        )
-
-target_compile_definitions(int2 INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
-target_compile_definitions(int2_static INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
-
-# Add libraries to the list of installed components
-install(TARGETS int2 int2_static EXPORT libint2
+  target_compile_definitions(int2_static INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
+  # Add libraries to the list of installed components
+  install(TARGETS int2_static EXPORT libint2
         COMPONENT int2
         LIBRARY DESTINATION "${LIBINT2_INSTALL_LIBDIR}"
         ARCHIVE DESTINATION "${LIBINT2_INSTALL_LIBDIR}"
         # includes are installed by the include/CMakeLists.txt.include.export
         # INCLUDES DESTINATION "${LIBINT2_INSTALL_INCLUDEDIR}"
        )
+else()
+  add_library(int2 $<TARGET_OBJECTS:int2_obj>)
+endif()
+# In any case, there will exist a target named "int2": diminish code length by
+# add just once the needed includes, flags and install directives.
+  target_include_directories(int2 INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/libint2>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}>
+        )
+  target_compile_definitions(int2 INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
+  # Add libraries to the list of installed components
+  install(TARGETS int2 EXPORT libint2
+        COMPONENT int2
+        LIBRARY DESTINATION "${LIBINT2_INSTALL_LIBDIR}"
+        ARCHIVE DESTINATION "${LIBINT2_INSTALL_LIBDIR}"
+        # includes are installed by the include/CMakeLists.txt.include.export
+        # INCLUDES DESTINATION "${LIBINT2_INSTALL_INCLUDEDIR}"
+       )
+
+
 add_subdirectory(include)
 
 # install basis set library
@@ -196,7 +209,11 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/lib/basis
 if (LIBINT_HAS_EIGEN)
   add_library(cxx INTERFACE)
   target_compile_features(cxx INTERFACE "cxx_std_11")
-  target_link_libraries(cxx INTERFACE int2 Eigen)
+  if (TARGET int2_static)
+    target_link_libraries(cxx INTERFACE int2_static Eigen)
+  else()
+    target_link_libraries(cxx INTERFACE int2 Eigen)
+  endif()
   if (LIBINT_HAS_SYSTEM_BOOST_PREPROCESSOR_VARIADICS)
       target_include_directories(cxx INTERFACE ${Boost_INCLUDE_DIR})
   endif(LIBINT_HAS_SYSTEM_BOOST_PREPROCESSOR_VARIADICS)
@@ -220,7 +237,11 @@ enable_testing(true)
 add_custom_target(check USES_TERMINAL COMMAND ${CMAKE_CTEST_COMMAND} -V)
 
 add_executable(eritest EXCLUDE_FROM_ALL tests/eri/test.cc)
-target_link_libraries(eritest int2_static)
+if (TARGET int2_static)
+    target_link_libraries(eritest int2_static)
+  else ()
+    target_link_libraries(eritest int2)
+endif()
 target_include_directories(eritest PRIVATE ${CMAKE_SOURCE_DIR}/tests/eri)
 
 add_test(eritest/build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target eritest)

--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -141,25 +141,32 @@ set(LIB_CXX_SRC )
 foreach(FN IN LISTS LIBINT2_LIBRARY_CXX_SRC)
     list(APPEND LIB_CXX_SRC "src/${FN}")
 endforeach()
-add_library(int2 ${LIB_CXX_SRC})
-target_include_directories(int2 PRIVATE include ${PROJECT_BINARY_DIR}/include)
-target_include_directories(int2 INTERFACE
+# Create object files to use for static and shared libraries
+add_library(int2_obj OBJECT ${LIB_CXX_SRC})
+target_include_directories(int2_obj PRIVATE include ${PROJECT_BINARY_DIR}/include)
+# Compile static library with position independent code
+set_target_properties(int2_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(int2_obj INTERFACE
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/libint2>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}>
         )
-target_compile_definitions(int2 PRIVATE __COMPILING_LIBINT2)
-target_compile_definitions(int2 INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
-target_compile_features(int2 PUBLIC "cxx_std_11")
+target_compile_definitions(int2_obj PRIVATE __COMPILING_LIBINT2)
+target_compile_definitions(int2_obj INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
+target_compile_features(int2_obj PUBLIC "cxx_std_11")
 if (TARGET MPFR::GMPXX)
-  target_link_libraries(int2 PUBLIC MPFR::GMPXX)
+  target_link_libraries(int2_obj PUBLIC MPFR::GMPXX)
 endif()
 if (NOT CMAKE_CXX_EXTENSIONS)
   set_target_properties(int2 PROPERTIES CXX_EXTENSIONS OFF)
 endif(NOT CMAKE_CXX_EXTENSIONS)
 
-# Add library to the list of installed components
-install(TARGETS int2 EXPORT libint2
+# shared and static libraries built from the same object files
+add_library(int2 SHARED $<TARGET_OBJECTS:int2_obj>)
+add_library(int2_static STATIC $<TARGET_OBJECTS:int2_obj>)
+
+# Add libraries to the list of installed components
+install(TARGETS int2 int2_static EXPORT libint2
         COMPONENT int2
         LIBRARY DESTINATION "${LIBINT2_INSTALL_LIBDIR}"
         ARCHIVE DESTINATION "${LIBINT2_INSTALL_LIBDIR}"
@@ -203,7 +210,7 @@ enable_testing(true)
 add_custom_target(check USES_TERMINAL COMMAND ${CMAKE_CTEST_COMMAND} -V)
 
 add_executable(eritest EXCLUDE_FROM_ALL tests/eri/test.cc)
-target_link_libraries(eritest int2)
+target_link_libraries(eritest int2_static)
 target_include_directories(eritest PRIVATE ${CMAKE_SOURCE_DIR}/tests/eri)
 add_test(eritest/build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target eritest)
 set_tests_properties(eritest/build PROPERTIES FIXTURES_SETUP ERITEST_EXEC)
@@ -333,7 +340,7 @@ if (ENABLE_FORTRAN)
 
     # tests
     add_executable(fortran_example EXCLUDE_FROM_ALL fortran/fortran_example.F90)
-    target_link_libraries(fortran_example libint_f int2)
+    target_link_libraries(fortran_example libint_f int2_static)
     add_test(fortran_example/build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target fortran_example)
     set_tests_properties(fortran_example/build PROPERTIES FIXTURES_SETUP FORTRAN_EXAMPLE_EXEC)
     add_test(NAME fortran_example/run

--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -200,6 +200,12 @@ endif()
 
 add_subdirectory(include)
 
+if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
+  set(int2_library int2_static)
+else()
+  set(int2_library int2)
+endif()
+
 # install basis set library
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/lib/basis
         COMPONENT int2
@@ -211,11 +217,7 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/lib/basis
 if (LIBINT_HAS_EIGEN)
   add_library(cxx INTERFACE)
   target_compile_features(cxx INTERFACE "cxx_std_11")
-  if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
-    target_link_libraries(cxx INTERFACE int2_static Eigen)
-  else()
-    target_link_libraries(cxx INTERFACE int2 Eigen)
-  endif()
+  target_link_libraries(cxx INTERFACE ${int2_library} Eigen)
   if (LIBINT_HAS_SYSTEM_BOOST_PREPROCESSOR_VARIADICS)
       target_include_directories(cxx INTERFACE ${Boost_INCLUDE_DIR})
   endif(LIBINT_HAS_SYSTEM_BOOST_PREPROCESSOR_VARIADICS)
@@ -239,11 +241,7 @@ enable_testing(true)
 add_custom_target(check USES_TERMINAL COMMAND ${CMAKE_CTEST_COMMAND} -V)
 
 add_executable(eritest EXCLUDE_FROM_ALL tests/eri/test.cc)
-if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
-    target_link_libraries(eritest int2_static)
-else ()
-    target_link_libraries(eritest int2)
-endif()
+target_link_libraries(eritest ${int2_library})
 target_include_directories(eritest PRIVATE ${CMAKE_SOURCE_DIR}/tests/eri)
 
 add_test(eritest/build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target eritest)
@@ -374,9 +372,7 @@ if (ENABLE_FORTRAN)
 
     # tests
     add_executable(fortran_example EXCLUDE_FROM_ALL fortran/fortran_example.F90)
-    if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
-      target_link_libraries(fortran_example libint_f int2_static)
-    endif()
+    target_link_libraries(fortran_example libint_f ${int2_library})
     add_test(fortran_example/build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target fortran_example)
     set_tests_properties(fortran_example/build PROPERTIES FIXTURES_SETUP FORTRAN_EXAMPLE_EXEC)
     add_test(NAME fortran_example/run

--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -318,7 +318,8 @@ if (ENABLE_FORTRAN)
             )
 
     # build module
-    add_library(libint_f OBJECT fortran/libint_f.F90 ${CMAKE_BINARY_DIR}/fortran/libint2_types_f.h ${CMAKE_BINARY_DIR}/fortran/fortran_incldefs.h)
+    add_library(libint_f OBJECT fortran/libint_f.F90)
+    set_source_files_properties(fortran/libint_f.F90 PROPERTIES OBJECT_DEPENDS "${CMAKE_BINARY_DIR}/fortran/libint2_types_f.h;${CMAKE_BINARY_DIR}/fortran/fortran_incldefs.h")
     target_include_directories(libint_f PUBLIC
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
             $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>

--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -146,24 +146,34 @@ add_library(int2_obj OBJECT ${LIB_CXX_SRC})
 target_include_directories(int2_obj PRIVATE include ${PROJECT_BINARY_DIR}/include)
 # Compile static library with position independent code
 set_target_properties(int2_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_include_directories(int2_obj INTERFACE
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/libint2>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}>
-        )
+
 target_compile_definitions(int2_obj PRIVATE __COMPILING_LIBINT2)
-target_compile_definitions(int2_obj INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
 target_compile_features(int2_obj PUBLIC "cxx_std_11")
 if (TARGET MPFR::GMPXX)
   target_link_libraries(int2_obj PUBLIC MPFR::GMPXX)
 endif()
 if (NOT CMAKE_CXX_EXTENSIONS)
-  set_target_properties(int2 PROPERTIES CXX_EXTENSIONS OFF)
+  set_target_properties(int2_obj PROPERTIES CXX_EXTENSIONS OFF)
 endif(NOT CMAKE_CXX_EXTENSIONS)
 
 # shared and static libraries built from the same object files
 add_library(int2 SHARED $<TARGET_OBJECTS:int2_obj>)
 add_library(int2_static STATIC $<TARGET_OBJECTS:int2_obj>)
+
+target_include_directories(int2 INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/libint2>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}>
+        )
+
+target_include_directories(int2_static INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/libint2>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}>
+        )
+
+target_compile_definitions(int2 INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
+target_compile_definitions(int2_static INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
 
 # Add libraries to the list of installed components
 install(TARGETS int2 int2_static EXPORT libint2
@@ -212,6 +222,7 @@ add_custom_target(check USES_TERMINAL COMMAND ${CMAKE_CTEST_COMMAND} -V)
 add_executable(eritest EXCLUDE_FROM_ALL tests/eri/test.cc)
 target_link_libraries(eritest int2_static)
 target_include_directories(eritest PRIVATE ${CMAKE_SOURCE_DIR}/tests/eri)
+
 add_test(eritest/build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target eritest)
 set_tests_properties(eritest/build PROPERTIES FIXTURES_SETUP ERITEST_EXEC)
 add_test(NAME eritest/run0


### PR DESCRIPTION
Currently, in the cmake project, only a static library is produced (libint2.a). This library is compiled without setting the position independent code property to `ON`. This prevents the subsequent linking of the library in a shared library. 

I did it in my local repo, but I thought to spread my solution with the project.

In order to do so, I propose to 
a) add the said property (`set_target_property PROPERTIES POSITION_INDEPENDENT_CODE ON`) to the obejct file produced for the `int2` library.
b) produce a shared and a static version of the libraries without increasing the compile time. This is done by compiling an object file `int2_obj` and subsequently creating a `STATIC` `int2_static` and a `SHARED` `int2` target form it. Compile time is thus the same.

Now both versions are available for linking. No further problem with shared projects is envisioned. Tests are linked to the shared version to save some time at link stage. 