### PR TITLE
LIBINT2_MAX_AM_default2 definition

### DIFF
--- a/src/bin/libint/build_libint.cc
+++ b/src/bin/libint/build_libint.cc
@@ -785,7 +785,12 @@ BOOST_PP_LIST_FOR_EACH ( BOOST_PP_ONEBODY_MCR1, _, BOOST_PP_ONEBODY_TASK_LIST)
   }
 #else
   iface->to_params(iface->macro_define("MAX_AM",LIBINT_MAX_AM));
-  iface->to_params(iface->macro_define("MAX_AM_default",LIBINT_MAX_AM));
+  for(unsigned int d=0; d<=INCLUDE_ERI; ++d) {
+    std::ostringstream oss;
+    oss << "MAX_AM_default";
+    if (d > 0) oss << d;
+    iface->to_params(iface->macro_define(oss.str(),LIBINT_MAX_AM));
+  }
 #endif
   cparams->print(os);
 


### PR DESCRIPTION
In linking against libint2 built with derivatives, Psi4 folks have noticed errors like the below

```
/home/psilocaluser/gits/hrw-quaternary/objdir_dev10_gcc4/stage/include/libint2/engine.impl.h: In member function 'void libint2::Engine::_initialize()':
/home/psilocaluser/gits/hrw-quaternary/objdir_dev10_gcc4/stage/include/libint2/engine.impl.h:627:3: error: 'LIBINT2_MAX_AM_default1' was not declared in this scope
   BOOST_PP_LIST_FOR_EACH_PRODUCT(
   ^
/home/psilocaluser/gits/hrw-quaternary/objdir_dev10_gcc4/stage/include/libint2/engine.impl.h:627:3: note: suggested alternative: 'LIBINT2_MAX_AM_default'
```

We've been patching them up and proceeding (step (5) of https://github.com/psi4/psi4/pull/1721#issuecomment-537945417). This is an attempt at a more permanent solution. It does write the extra defines to `libint2_params.h`, but maybe it's doing untold harm somewhere else. And the fact that it's using the max ERI deriv level instead of the max of all integrals classes is admittedly bad.

```
#ifndef LIBINT2_MAX_AM_default					#ifndef LIBINT2_MAX_AM_default
# define LIBINT2_MAX_AM_default 4				# define LIBINT2_MAX_AM_default 4
#endif								#endif

							      >	#ifndef LIBINT2_MAX_AM_default1
							      >	# define LIBINT2_MAX_AM_default1 4
							      >	#endif
							      >
							      >	#ifndef LIBINT2_MAX_AM_default2
							      >	# define LIBINT2_MAX_AM_default2 4
							      >	#endif
							      >
#ifndef LIBINT2_MAX_AM_overlap					#ifndef LIBINT2_MAX_AM_overlap
# define LIBINT2_MAX_AM_overlap 4				# define LIBINT2_MAX_AM_overlap 4
#endif								#endif
```