### PR TITLE
Clarify angular momentum constraints

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,7 +135,7 @@ AC_ARG_WITH(shell-set,
                              for (ab|cd):
                                l(a) >= l(b),
                                l(c) >= l(d),
-                               l(a)+l(b) <= l(c)+l(d)
+                               l(a)+l(b) >= l(c)+l(d)
                              for (b|cd):
                                l(c) >= l(d)
                            orca -- ORCA ordering:

--- a/doc/progman/progman.tex
+++ b/doc/progman/progman.tex
@@ -485,7 +485,7 @@ configured with {\tt --enable-flop-counter}).
 {\bf Note} that currently the \LIBINT\ compiler minimizes the amount of code it
 generates by taking advantage of the permutational symmetry of the integrals.
 This means that only certain combinations of the angular momenta can be handled.
-In standard configuration \LIBINT\ can evaluate a shell quartet $({\bf ab}|{\bf cd})$ if $\lambda({\bf a}) \geq \lambda({\bf b})$, $\lambda({\bf c}) \geq \lambda({\bf d})$, and $\lambda({\bf c}) + \lambda({\bf d}) \geq \lambda({\bf a}) + \lambda({\bf b})$.
+In standard configuration \LIBINT\ can evaluate a shell quartet $({\bf ab}|{\bf cd})$ if $\lambda({\bf a}) \geq \lambda({\bf b})$, $\lambda({\bf c}) \geq \lambda({\bf d})$, and $\lambda({\bf a}) + \lambda({\bf b}) \geq \lambda({\bf c}) + \lambda({\bf d})$.
 (There is also the ordering used by {\tt ORCA} program for which \LIBINT\ can be
 configured --- it will not be discussed here). If one needs to compute a quartet that doesn't conform the rule,
 e.g. of type $(pf|sd)$, permutational symmetry of integrals can be utilized to compute such quartet:


### PR DESCRIPTION
First of all, thanks for all of your work on this excellent project!  I've been (very belatedly) working to hook the code into Psi4 via the new C++11 interface and have a question about angular momentum requirements.  The documentation states that the angular momenta should be ordered as

`A >= B, C >= D, CD >= AB`

which is consistent with how the original libint was used in both Psi3 and Psi4.  While this gives correct energies, it doesn't seem to work for derivatives.  If I instead use the ordering

`A >= B, C >= D, AB >= CD`

I seem to get correct energies and gradients, and this ordering is consistent with the [example Hartree-Fock code](https://github.com/evaleev/libint/blob/master/tests/hartree-fock/hartree-fock%2B%2B.cc#L1593-L1605).  Am I correct to assume that this ordering is to be used?  Also, am I safe in assuming that the translational invariance relations are always applied, such that the derivative buffers always contain `Ax,Ay,Az,Bx,By,Bz,Dx,Dy,Dz,Cx,Cy,Cz`?  my tests so far seem to indicate that this is true, but I just want to make sure I'm safe to assume this going forwards.

This PR will adjust the couple of places in the docs that I'm aware of the angular momentum requirements being stated - please just close it if I'm wrong about this.