### PR TITLE
Bump minimum required Boost version to 1.57 (`BOOST_PP_VARIADICS`)

### DIFF
--- a/configure
+++ b/configure
@@ -6853,10 +6853,10 @@ BOOST_CPPFLAGS=""
 if test "x$want_boost" = "xyes"; then :
 
 
-  if test "x1.30" = "x"; then :
+  if test "x1.57" = "x"; then :
   _AX_BOOST_BASE_TONUMERICVERSION_req="1.20.0"
 else
-  _AX_BOOST_BASE_TONUMERICVERSION_req="1.30"
+  _AX_BOOST_BASE_TONUMERICVERSION_req="1.57"
 fi
   _AX_BOOST_BASE_TONUMERICVERSION_req_shorten=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([0-9]*\.[0-9]*\)'`
   _AX_BOOST_BASE_TONUMERICVERSION_req_major=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([0-9]*\)'`
@@ -6898,16 +6898,16 @@ esac
 
                 if test "x$_AX_BOOST_BASE_boost_path" != "x"; then :
 
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.30 ($WANT_BOOST_VERSION) includes in \"$_AX_BOOST_BASE_boost_path/include\"" >&5
-$as_echo_n "checking for boostlib >= 1.30 ($WANT_BOOST_VERSION) includes in \"$_AX_BOOST_BASE_boost_path/include\"... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.57 ($WANT_BOOST_VERSION) includes in \"$_AX_BOOST_BASE_boost_path/include\"" >&5
+$as_echo_n "checking for boostlib >= 1.57 ($WANT_BOOST_VERSION) includes in \"$_AX_BOOST_BASE_boost_path/include\"... " >&6; }
          if test -d "$_AX_BOOST_BASE_boost_path/include" && test -r "$_AX_BOOST_BASE_boost_path/include"; then :
 
            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
            BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path/include"
            for _AX_BOOST_BASE_boost_path_tmp in $multiarch_libsubdir $libsubdirs; do
-                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.30 ($WANT_BOOST_VERSION) lib path in \"$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp\"" >&5
-$as_echo_n "checking for boostlib >= 1.30 ($WANT_BOOST_VERSION) lib path in \"$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp\"... " >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.57 ($WANT_BOOST_VERSION) lib path in \"$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp\"" >&5
+$as_echo_n "checking for boostlib >= 1.57 ($WANT_BOOST_VERSION) lib path in \"$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp\"... " >&6; }
                 if test -d "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp" && test -r "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp" ; then :
 
                         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
@@ -6950,8 +6950,8 @@ fi
   BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_lib_path"
 fi
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.30 ($WANT_BOOST_VERSION)" >&5
-$as_echo_n "checking for boostlib >= 1.30 ($WANT_BOOST_VERSION)... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.57 ($WANT_BOOST_VERSION)" >&5
+$as_echo_n "checking for boostlib >= 1.57 ($WANT_BOOST_VERSION)... " >&6; }
     CPPFLAGS_SAVED="$CPPFLAGS"
     CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
     export CPPFLAGS
@@ -7120,14 +7120,14 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
     if test "x$succeeded" != "xyes" ; then
         if test "x$_version" = "x0" ; then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: We could not detect the boost libraries (version 1.30 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&5
-$as_echo "$as_me: We could not detect the boost libraries (version 1.30 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&6;}
+            { $as_echo "$as_me:${as_lineno-$LINENO}: We could not detect the boost libraries (version 1.57 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&5
+$as_echo "$as_me: We could not detect the boost libraries (version 1.57 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&6;}
         else
             { $as_echo "$as_me:${as_lineno-$LINENO}: Your boost libraries seems to old (version $_version)." >&5
 $as_echo "$as_me: Your boost libraries seems to old (version $_version)." >&6;}
         fi
         # execute ACTION-IF-NOT-FOUND (if present):
-        as_fn_error $? "libint compiler needs Boost 1.30 or later (needs Boost 1.57 if don't want to use bundled Boost.Preprocessor and be able to use clang), download from https://www.boost.org/users/download/ , unpack (no need to install), and add -I/path/to/boost to CPPFLAGS" "$LINENO" 5
+        as_fn_error $? "libint compiler needs Boost 1.57 or later (needs Boost 1.57 if don't want to use bundled Boost.Preprocessor and be able to use clang), download from https://www.boost.org/users/download/ , unpack (no need to install), and add -I/path/to/boost to CPPFLAGS" "$LINENO" 5
     else
 
 $as_echo "#define HAVE_BOOST /**/" >>confdefs.h

--- a/configure.ac
+++ b/configure.ac
@@ -1314,8 +1314,8 @@ AC_ARG_ENABLE(mpfr,
 
 dnl ------------------ Check for Boost library -----------------------
 
-dnl Boost.Preprocessor requires 1.30 (which introduced MPL; Preprocessor was introduced in 1.29)
-AX_BOOST_BASE([1.30],, [AC_MSG_ERROR([libint compiler needs Boost 1.30 or later (needs Boost 1.57 if don't want to use bundled Boost.Preprocessor and be able to use clang), download from https://www.boost.org/users/download/ , unpack (no need to install), and add -I/path/to/boost to CPPFLAGS])])
+dnl Boost.Preprocessor requires 1.57
+AX_BOOST_BASE([1.57],, [AC_MSG_ERROR([libint compiler needs Boost 1.57 or later (needs Boost 1.57 if don't want to use bundled Boost.Preprocessor and be able to use clang), download from https://www.boost.org/users/download/ , unpack (no need to install), and add -I/path/to/boost to CPPFLAGS])])
 CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
 # no need to update LDFLAGS: we are not using precompoiled boost
 


### PR DESCRIPTION
`BOOST_PP_VARIADICS` is introduced in Boost 1.49: https://github.com/boostorg/preprocessor/blob/boost-1.48.0/include/boost/preprocessor/config/config.hpp vs https://github.com/boostorg/preprocessor/blob/boost-1.49.0/include/boost/preprocessor/config/config.hpp#L73-L103

fix #179