### PR TITLE
Remove default args from function implementation

### DIFF
--- a/include/libint2/boys.h
+++ b/include/libint2/boys.h
@@ -1841,9 +1841,9 @@ namespace libint2 {
   void stg_ng_fit(unsigned int n,
                  Real zeta,
                  std::vector< std::pair<Real, Real> >& geminal,
-                 Real xmin = 0.0,
-                 Real xmax = 10.0,
-                 unsigned int npts = 1001) {
+                 Real xmin,
+                 Real xmax,
+                 unsigned int npts) {
 
     // initial guess
     std::vector<Real> cc(n, 1.0); // coefficients


### PR DESCRIPTION
This function gives values for the default arguments in the definition `boys_fwd.h` and in the implementation `boys.h`, and I think this is only needed in one place. I made a [breaking example](https://gist.github.com/shivupa/655e50a8193665663fb2681dcef94ec8) using the `hartree-fock.cc` example. It is only an issue when `HAVE_LAPACK` is true. 