### PR TITLE
Sort input file list

### DIFF
--- a/src/lib/libint/Makefile.library
+++ b/src/lib/libint/Makefile.library
@@ -17,12 +17,12 @@ default:: $(TOPDIR)/lib/$(TARGET) local_install_generated_headers
 # NOTE: the library is made from scratch every time and the prerequisite variable is not used to avoid overflow
 $(TOPDIR)/lib/$(NAME).a: $(LIBOBJ)
 	/bin/rm -f $@
-	find . -name '*.$(OBJSUF)' -print0 | xargs -0 $(AR) $(ARFLAGS) $@
+	find . -name '*.$(OBJSUF)' -print0 | sort -z | xargs -0 $(AR) $(ARFLAGS) $@
 	$(RANLIB) $@
 
 # this is how shared library is made
 $(TOPDIR)/lib/$(NAME).la: $(LIBOBJ)
-	find . -name '*.$(OBJSUF)' -print > libobjlist
+	find . -name '*.$(OBJSUF)' -print | sort > libobjlist
 	$(LTLINK) $(CXX) -o $@ -objectlist libobjlist $(LTLINKLIBOPTS)
 	-rm -f libobjlist
 


### PR DESCRIPTION
Sort input file list
so that `libint2.so.2.0.3` builds in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on [reproducible builds](https://reproducible-builds.org/) for [openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).