### PR TITLE
Alias CMake Targets for In-Source Builds

### DIFF
--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -231,6 +231,8 @@ target_include_directories(libint2 INTERFACE
 target_compile_features(libint2 INTERFACE "cxx_std_11")
 # need to define __COMPILING_LIBINT2 whenever using libint targets in the build tree
 target_compile_definitions(libint2 INTERFACE $<BUILD_INTERFACE:__COMPILING_LIBINT2>)
+# Alias libint2 -> Libint2::int2 for in-source builds
+add_library(Libint2::int2 ALIAS libint2) 
 # Add libraries to the list of installed components
 install(TARGETS libint2 EXPORT libint2
     COMPONENT libint2
@@ -275,6 +277,8 @@ if (LIBINT_HAS_CXX_API)
           # includes are installed by the include/CMakeLists.txt.include.export
           # INCLUDES DESTINATION "${LIBINT2_INSTALL_INCLUDEDIR}"
           )
+  # Alias libint2_cxx -> Libint2::cxx for in-source builds
+  add_library(Libint2::cxx ALIAS libint2_cxx)
 endif(LIBINT_HAS_CXX_API)
 
 # Tests ================================================================================================================


### PR DESCRIPTION
Make it so find/build targets are the same in exported CMake build. Previously, the build targets were named e.g. `int2` and `cxx` whereas the installed targets were namespaced `Libint2::`. This PR allow for the following

```
cmake_minimum_required( VERSION 3.17 FATAL_ERROR )
project( libint2-as-subproject LANGUAGES CXX )

find_package( Libint2 )
if( NOT Libint2_FOUND )
  include( FetchContent )
  FetchContent_Declare( libint2
    URL https://.......
  )
  FetchContent_MakeAvailable( libint2 )
endif()

add_executable( my_exe test.cxx )
target_link_libraries( my_exe PUBLIC Libint2::int2 )
```