### PR TITLE
new primitive screening methods

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -129,6 +129,6 @@ jobs:
         add_executable(hf++ EXCLUDE_FROM_ALL $LIBINT_EXPORTED_DIR/tests/hartree-fock/hartree-fock++.cc)
         target_link_libraries(hf++ Libint2::cxx Threads::Threads)
         EOF
-        cmake . -DCMAKE_PREFIX_PATH=${{github.workspace}}/build/library/install
+        cmake . -DCMAKE_PREFIX_PATH=${{github.workspace}}/build/library/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE
         cmake --build . --target hf++
         ./hf++ $LIBINT_EXPORTED_DIR/tests/hartree-fock/h2o_rotated.xyz | python $LIBINT_EXPORTED_DIR/tests/hartree-fock/hartree-fock++-validate.py $LIBINT_EXPORTED_DIR/MakeVars.features

--- a/CHANGES
+++ b/CHANGES
@@ -3,10 +3,13 @@
 
 Following is a brief summary of changes made in each release of Libint.
 
+- 2022-xx-yy: 2.8.0-beta.1
+  - PR #232: introduced new primitive screening methods
+
 - 2021-09-19: 2.7.1
-  - PR 224: fixed tracking of shell-pair data
-  - PR 223: removed redundant const qualifier (HT @e-kwsm)
-  - issue 222: fixed compiler tree's install target
+  - PR #224: fixed tracking of shell-pair data
+  - PR #223: removed redundant const qualifier (HT @e-kwsm)
+  - issue #222: fixed compiler tree's install target
 
 - 2021-09-14: 2.7.0
   - precision tracking of shell-pair data, respected by Engine::compute2

--- a/bin/take_boostpp_snapshot.sh
+++ b/bin/take_boostpp_snapshot.sh
@@ -8,7 +8,7 @@ TARBALL=boost_${VERSION_}.tar.bz2
 
 #### download
 if ! test -f ${TARBALL}; then
-  BOOST_URL=https://sourceforge.net/projects/boost/files/boost/${VERSION}/${TARBALL}/download
+  BOOST_URL=https://boostorg.jfrog.io/artifactory/main/release/${VERSION}/${TARBALL}
   curl -o ${TARBALL} -L ${BOOST_URL} 
 fi
 

--- a/include/libint2/basis.h.in
+++ b/include/libint2/basis.h.in
@@ -50,7 +50,7 @@ namespace libint2 {
   /// @return the number of basis functions
   template <typename ShellRange> size_t nbf(ShellRange && shells) {
     size_t n = 0;
-    for (const auto& shell: std::forward<ShellRange>(shells))
+    for (auto&& shell: std::forward<ShellRange>(shells))
       n += shell.size();
     return n;
   }
@@ -61,7 +61,7 @@ namespace libint2 {
   /// @return the maximum number of primitives
   template <typename ShellRange> size_t max_nprim(ShellRange && shells) {
     size_t n = 0;
-    for (auto shell: std::forward<ShellRange>(shells))
+    for (auto&& shell: std::forward<ShellRange>(shells))
       n = std::max(shell.nprim(), n);
     return n;
   }
@@ -72,16 +72,27 @@ namespace libint2 {
   /// @return the maximum angular momentum
   template <typename ShellRange> int max_l(ShellRange && shells) {
     int l = 0;
-    for (auto shell: std::forward<ShellRange>(shells))
-      for (auto c: shell.contr)
+    for (auto&& shell: std::forward<ShellRange>(shells))
+      for (auto&& c: shell.contr)
         l = std::max(c.l, l);
     return l;
+  }
+
+  /// Computes the maximum size of any Shell among a range of shells
+  /// @tparam a range type
+  /// @param[in] shells a sequence of shells
+  /// @return the maximum size of a shell in @p shells
+  template <typename ShellRange> size_t max_size(ShellRange && shells) {
+    size_t n = 0;
+    for (auto&& shell: std::forward<ShellRange>(shells))
+      n = std::max(shell.size(), n);
+    return n;
   }
 
   /// BasisSet is a slightly decorated \c std::vector of \c libint2::Shell objects.
   class BasisSet : public std::vector<libint2::Shell> {
     public:
-      BasisSet() : name_(""), nbf_(-1), max_nprim_(0), max_l_(-1) {}
+      BasisSet() : name_(""), nbf_(-1), max_nprim_(0), max_l_(-1), max_size_(0) {}
       BasisSet(const BasisSet&) = default;
       BasisSet(BasisSet&& other) :
         std::vector<libint2::Shell>(std::move(other)),
@@ -89,6 +100,7 @@ namespace libint2 {
         nbf_(other.nbf_),
         max_nprim_(other.max_nprim_),
         max_l_(other.max_l_),
+        max_size_(other.max_size_),
         shell2bf_(std::move(other.shell2bf_))
       {
       }
@@ -211,17 +223,21 @@ namespace libint2 {
         init();
       }
 
-      /// @return the number of basis functions in the basis; -1 if uninitialized
+      /// @return the number of basis functions in the basis; -1, if `*this` is in a null (default-initialized) state
       long nbf() const {
         return nbf_;
       }
-      /// @return the maximum number of primitives in a contracted Shell, i.e. maximum contraction length; 0 if uninitialized
+      /// @return the maximum number of primitives in a contracted Shell, i.e. maximum contraction length; 0, if `*this` is in a null (default-initialized) state
       size_t max_nprim() const {
         return max_nprim_;
       }
-      /// @return the maximum angular momentum of a contraction; -1 if uninitialized
+      /// @return the maximum angular momentum of a contraction; -1, if `*this` is in a null (default-initialized) state
       long max_l() const {
         return max_l_;
+      }
+      /// @return the maximum size of a shell; 0, if `*this` is in a null (default-initialized) state
+      size_t max_size() const {
+        return max_nprim_;
       }
       /// @return the map from shell index to index of the first basis function from this shell
       /// \note basis functions are ordered as shells, i.e. shell2bf[i] >= shell2bf[j] iff i >= j
@@ -285,12 +301,14 @@ namespace libint2 {
       long nbf_;
       size_t max_nprim_;
       int max_l_;
+      size_t max_size_;
       std::vector<size_t> shell2bf_;
 
       void init() {
         nbf_ = libint2::nbf(*this);
         max_nprim_ = libint2::max_nprim(*this);
         max_l_ = libint2::max_l(*this);
+        max_size_ = libint2::max_size(*this);
         shell2bf_ = compute_shell2bf(*this);
       }
 

--- a/include/libint2/engine.h
+++ b/include/libint2/engine.h
@@ -766,12 +766,15 @@ class Engine {
     if (prec <= 0.) {
       precision_ = 0.;
       ln_precision_ = std::numeric_limits<scalar_type>::lowest();
-    } else {
+      return *this;
+    }
+    if (prec > 0.) {  // split single if/else to avoid speculative execution of else branch on Apple M1 with apple clang 13.0.0
       precision_ = prec;
       using std::log;
       ln_precision_ = log(precision_);
+      return *this;
     }
-    return *this;
+    abort();
   }
   /// @return the target precision for computing the integrals
   /// @sa set_precision(scalar_type)

--- a/include/libint2/engine.h
+++ b/include/libint2/engine.h
@@ -618,7 +618,7 @@ class Engine {
   int deriv_order() const { return deriv_order_; }
 
   /// @return the primitive screening method
-  ScreeningMethod scheening_method() const { return screening_method_; }
+  ScreeningMethod screening_method() const { return screening_method_; }
 
   /// (re)sets operator type to @c new_oper
   /// @param[in] new_oper Operator whose integrals will be computed with the next call to Engine::compute()

--- a/include/libint2/engine.h
+++ b/include/libint2/engine.h
@@ -415,6 +415,7 @@ class Engine {
   } empty_pod;
 
  public:
+
   static constexpr auto max_ntargets =
       std::extent<decltype(std::declval<Libint_t>().targets), 0>::value;
   using target_ptr_vec =
@@ -446,23 +447,20 @@ class Engine {
   /// \throw Engine::lmax_exceeded if \c max_l exceeds the angular momentum
   /// limit of the library
   /// \param deriv_order if not 0, will compute geometric derivatives of
-  /// Gaussian integrals of order \c deriv_order ,
-  ///                    (default=0)
+  ///        Gaussian integrals of order \c deriv_order
+  ///        (default=0, i.e. compute nondifferentiated integrals)
   /// \param precision specifies the target precision with which the integrals
-  /// will be computed; the default is the "epsilon"
-  ///        of \c scalar_type type, given by \c
-  ///        std::numeric_limits<scalar_type>::epsilon(). Currently precision control
-  ///        is implemented
-  ///        for two-body integrals only. The precision control is somewhat
-  ///        empirical,
-  ///        hence be conservative. \sa set_precision()
-  /// \param params a value of type
-  /// Engine::operator_traits<oper>::oper_params_type specifying the parameters
-  /// of
+  ///        will be computed; the default is the
+  ///        `std::numeric_limits<scalar_type>::epsilon()`.
+  ///        Currently the precision control is implemented
+  ///        for two-body integrals only.
+  ///        \sa Engine::set_precision()
+  /// \param params a value of type `Engine::operator_traits<oper>::oper_params_type`
+  ///               specifying the parameters of
   ///               the operator set, e.g. position and magnitude of the charges
   ///               creating the Coulomb potential
-  ///               for oper == Operator::nuclear, etc.
-  /// For most values of \c oper
+  ///               for `oper == Operator::nuclear`, etc.
+  ///               For most values of \c oper
   ///               this is not needed.
   ///               \sa Engine::operator_traits
   /// \param braket a value of BraKet type
@@ -472,7 +470,8 @@ class Engine {
   template <typename Params = empty_pod>
   Engine(Operator oper, size_t max_nprim, int max_l, int deriv_order = 0,
          scalar_type precision = std::numeric_limits<scalar_type>::epsilon(),
-         Params params = empty_pod(), BraKet braket = BraKet::invalid)
+         Params params = empty_pod(), BraKet braket = BraKet::invalid,
+         ScreeningMethod screening_method = default_screening_method())
       : oper_(oper),
         braket_(braket),
         primdata_(),
@@ -481,6 +480,7 @@ class Engine {
         stack_size_(0),
         lmax_(max_l),
         deriv_order_(deriv_order),
+        screening_method_(screening_method),
         cartesian_shell_normalization_(CartesianShellNormalization::standard),
         scale_(1),
         params_(enforce_params_type(oper, params)) {
@@ -508,6 +508,7 @@ class Engine {
         deriv_order_(other.deriv_order_),
         precision_(other.precision_),
         ln_precision_(other.ln_precision_),
+        screening_method_(other.screening_method_),
         cartesian_shell_normalization_(other.cartesian_shell_normalization_),
         scale_(other.scale_),
         core_eval_pack_(std::move(other.core_eval_pack_)),
@@ -536,6 +537,7 @@ class Engine {
         deriv_order_(other.deriv_order_),
         precision_(other.precision_),
         ln_precision_(other.ln_precision_),
+        screening_method_(other.screening_method_),
         cartesian_shell_normalization_(other.cartesian_shell_normalization_),
         scale_(other.scale_),
         core_eval_pack_(other.core_eval_pack_),
@@ -560,6 +562,7 @@ class Engine {
     deriv_order_ = other.deriv_order_;
     precision_ = other.precision_;
     ln_precision_ = other.ln_precision_;
+    screening_method_ = other.screening_method_;
     cartesian_shell_normalization_ = other.cartesian_shell_normalization_;
     scale_ = other.scale_;
     core_eval_pack_ = std::move(other.core_eval_pack_);
@@ -589,6 +592,7 @@ class Engine {
     deriv_order_ = other.deriv_order_;
     precision_ = other.precision_;
     ln_precision_ = other.ln_precision_;
+    screening_method_ = other.screening_method_;
     cartesian_shell_normalization_ = other.cartesian_shell_normalization_;
     scale_ = other.scale_;
     core_eval_pack_ = other.core_eval_pack_;
@@ -612,6 +616,9 @@ class Engine {
 
   /// @return the order of geometrical derivatives
   int deriv_order() const { return deriv_order_; }
+
+  /// @return the primitive screening method
+  ScreeningMethod scheening_method() const { return screening_method_; }
 
   /// (re)sets operator type to @c new_oper
   /// @param[in] new_oper Operator whose integrals will be computed with the next call to Engine::compute()
@@ -750,18 +757,18 @@ class Engine {
                                                              const ShellPair* spbra,
                                                              const ShellPair* spket);
 
-  /** this specifies target precision for computing the integrals.
-   * @param[in] prec the target precision
-   * @note target precision \f$ \epsilon \f$ is used in 3 ways:
-   *  (1) to screen out primitive pairs in ShellPair object for which
-   *      \f$ {\rm scr}_{12} = \max|c_1| \max|c_2| \exp(-\rho_{12}
-   * |AB|^2)/\gamma_{12} < \epsilon \f$ ;
-   *  (2) to screen out primitive quartets outside compute_primdata() for which
-   * \f$ {\rm scr}_{12} {\rm scr}_{34} <  \epsilon \f$;
-   *  (3) to screen out primitive quartets inside compute_primdata() for which
-   * the prefactor of \f$ F_m(\rho, T) \f$ is smaller
-   *      than \f$ \epsilon \f$ .
+  // clang-format off
+  /** this specifies target precision for computing the integrals, i.e.
+   *  the target absolute (i.e., not relative) error of the integrals.
+   *  It is used to screen out primitive integrals. For some screening
+   *  methods precision can be almost guaranteed (due to finite precision
+   *  of the precomputed interpolation tables used to evaluate the core integrals
+   *  it is not in general possible to guarantee precision rigorously).
+   *
+   *  @param[in] prec the target precision
+   *  @sa ScreeningMethod
    */
+  // clang-format on
   Engine& set_precision(scalar_type prec) {
     if (prec <= 0.) {
       precision_ = 0.;
@@ -779,6 +786,12 @@ class Engine {
   /// @return the target precision for computing the integrals
   /// @sa set_precision(scalar_type)
   scalar_type precision() const { return precision_; }
+
+  /// @param screening_method method used to screen primitive contributions
+  Engine& set(ScreeningMethod screening_method) { screening_method_ = screening_method; return *this; }
+
+  /// @return the method used to screen primitive contributions
+  ScreeningMethod screening_method() const { return screening_method_; }
 
   /// @return the Cartesian Gaussian normalization convention
   CartesianShellNormalization cartesian_shell_normalization() const {
@@ -886,6 +899,7 @@ class Engine {
   int deriv_order_;
   scalar_type precision_;
   scalar_type ln_precision_;
+  ScreeningMethod screening_method_ = ScreeningMethod::Invalid;
 
   // specifies the normalization convention for Cartesian Gaussians
   CartesianShellNormalization cartesian_shell_normalization_;

--- a/tests/hartree-fock/hartree-fock++.cc
+++ b/tests/hartree-fock/hartree-fock++.cc
@@ -60,6 +60,9 @@
 /// to use precomputed shell pair data must decide on max precision a priori
 const auto max_engine_precision = std::numeric_limits<double>::epsilon() / 1e10;
 
+// use conservative screening method
+constexpr auto screening_method = libint2::ScreeningMethod::SchwarzInf;
+
 // uncomment if want to report integral timings
 // N.B. integral engine timings are controled in engine.h
 #define REPORT_INTEGRAL_TIMINGS
@@ -77,6 +80,7 @@ using libint2::Atom;
 using libint2::BasisSet;
 using libint2::Operator;
 using libint2::BraKet;
+using libint2::ScreeningMethod;
 
 std::vector<Atom> read_geometry(const std::string& filename);
 Matrix compute_soad(const std::vector<Atom>& atoms);
@@ -288,12 +292,15 @@ int main(int argc, char* argv[]) {
 
     // compute OBS non-negligible shell-pair list
     {
+      const auto tstart = std::chrono::high_resolution_clock::now();
       std::tie(obs_shellpair_list, obs_shellpair_data) = compute_shellpairs(obs);
       size_t nsp = 0;
       for (auto& sp : obs_shellpair_list) {
         nsp += sp.second.size();
       }
-      std::cout << "# of {all,non-negligible} shell-pairs = {"
+      const auto tstop = std::chrono::high_resolution_clock::now();
+      const std::chrono::duration<double> time_elapsed = tstop - tstart;
+      std::cout << "computed shell-pair data in " << time_elapsed.count() << " seconds: # of {all,non-negligible} shell-pairs = {"
                 << obs.size() * (obs.size() + 1) / 2 << "," << nsp << "}"
                 << std::endl;
     }
@@ -1292,6 +1299,7 @@ compute_shellpairs(const BasisSet& bs1,
   engines.emplace_back(Operator::overlap,
                        std::max(bs1.max_nprim(), bs2.max_nprim()),
                        std::max(bs1.max_l(), bs2.max_l()), 0);
+  engines[0].set_precision(0.);
   for (size_t i = 1; i != nthreads; ++i) {
     engines.push_back(engines[0]);
   }
@@ -1361,12 +1369,37 @@ compute_shellpairs(const BasisSet& bs1,
   // compute shellpair data assuming that we are computing to default_epsilon
   // N.B. only parallelized over 1 shell index
   const auto ln_max_engine_precision = std::log(max_engine_precision);
+  // assume shellpair data are used for Coulomb ints
+  for(auto&& eng: engines) {
+    eng.set(Operator::coulomb);
+  }
   shellpair_data_t spdata(splist.size());
   auto make_spdata = [&](int thread_id) {
+    auto schwarz_factor_evaluator = [engine = &engines[thread_id]](const Shell& s1, size_t p1, const Shell& s2, size_t p2) -> double {
+      auto& buf = engine->results();
+      auto ps1 = s1.extract_primitive(p1, false);
+      auto ps2 = s2.extract_primitive(p2, false);
+      const auto n12 = ps1.size() * ps2.size();
+      engine->compute(ps1, ps2, ps1, ps2);
+      if (buf[0]) {
+        Eigen::Map<const Matrix> buf_mat(buf[0], n12, n12);
+        auto norm2 = screening_method == ScreeningMethod::SchwarzInf ? buf_mat.lpNorm<Eigen::Infinity>() : buf_mat.norm();
+        return std::sqrt(norm2);
+      }
+      else
+        return 0.;
+    };
     for (auto s1 = 0l; s1 != nsh1; ++s1) {
       if (s1 % nthreads == thread_id) {
-        for(const auto& s2 : splist[s1]) {
-          spdata[s1].emplace_back(std::make_shared<libint2::ShellPair>(bs1[s1],bs2[s2],ln_max_engine_precision));
+        for (const auto &s2 : splist[s1]) {
+          if (screening_method == ScreeningMethod::Original ||
+              screening_method == ScreeningMethod::Conservative)
+            spdata[s1].emplace_back(std::make_shared<libint2::ShellPair>(
+                bs1[s1], bs2[s2], ln_max_engine_precision, screening_method));
+          else {  // Schwarz screening of primitives
+            spdata[s1].emplace_back(std::make_shared<libint2::ShellPair>(
+                bs1[s1], bs2[s2], ln_max_engine_precision, screening_method, schwarz_factor_evaluator));
+          }
         }
       }
     }
@@ -1471,6 +1504,7 @@ Matrix compute_2body_2index_ints(const BasisSet& bs) {
   engines[0] =
       Engine(libint2::Operator::coulomb, bs.max_nprim(), bs.max_l(), 0);
   engines[0].set(BraKet::xs_xs);
+  engines[0].set(ScreeningMethod::Conservative);
   for (size_t i = 1; i != nthreads; ++i) {
     engines[i] = engines[0];
   }
@@ -1529,27 +1563,21 @@ Matrix compute_2body_fock(const BasisSet& obs, const Matrix& D,
       compute_shellblock_norm(obs, D);  // matrix of infty-norms of shell blocks
 
   auto fock_precision = precision;
-  // engine precision controls primitive truncation, assume worst-case scenario
-  // (all primitive combinations add up constructively)
+  // standard approach is to omit *contributions* to the Fock matrix smaller than fock_precision ... this relies on massive amount of error cancellation
   auto max_nprim = obs.max_nprim();
-  auto max_nprim4 = max_nprim * max_nprim * max_nprim * max_nprim;
-  auto engine_precision = std::min(fock_precision / D_shblk_norm.maxCoeff(),
-                                   std::numeric_limits<double>::epsilon()) /
-                          max_nprim4;
-  assert(engine_precision > max_engine_precision &&
+  auto needed_engine_precision = (fock_precision / D_shblk_norm.maxCoeff());
+  assert(needed_engine_precision > max_engine_precision &&
       "using precomputed shell pair data limits the max engine precision"
-  " ... make max_engine_precision smalle and recompile");
+  " ... make max_engine_precision smaller and recompile");
 
   // construct the 2-electron repulsion integrals engine pool
   using libint2::Engine;
   std::vector<Engine> engines(nthreads);
   engines[0] = Engine(Operator::coulomb, obs.max_nprim(), obs.max_l(), 0);
-  engines[0].set_precision(engine_precision);  // shellset-dependent precision
-                                               // control will likely break
-                                               // positive definiteness
-                                               // stick with this simple recipe
+  engines[0].set(screening_method);
+  engines[0].set_precision(needed_engine_precision);  // N.B. precision will be adjusted for each shellset
   std::cout << "compute_2body_fock:precision = " << precision << std::endl;
-  std::cout << "Engine::precision = " << engines[0].precision() << std::endl;
+  std::cout << "will set Engine::precision as low as = " << engines[0].precision() << std::endl;
   for (size_t i = 1; i != nthreads; ++i) {
     engines[i] = engines[0];
   }
@@ -1629,8 +1657,6 @@ Matrix compute_2body_fock(const BasisSet& obs, const Matrix& D,
             auto bf4_first = shell2bf[s4];
             auto n4 = obs[s4].size();
 
-            num_ints_computed += n1 * n2 * n3 * n4;
-
             // compute the permutational degeneracy (i.e. # of equivalents) of
             // the given shell set
             auto s12_deg = (s1 == s2) ? 1 : 2;
@@ -1642,11 +1668,15 @@ Matrix compute_2body_fock(const BasisSet& obs, const Matrix& D,
             timer.start(0);
 #endif
 
+            // vary precision for each shellset to guarantee precision of the contribution to the Fock matrix
+            engine.set_precision(Dnorm1234 != 0. ? fock_precision / Dnorm1234 : needed_engine_precision);
             engine.compute2<Operator::coulomb, BraKet::xx_xx, 0>(
                 obs[s1], obs[s2], obs[s3], obs[s4], sp12, sp34);
             const auto* buf_1234 = buf[0];
             if (buf_1234 == nullptr)
               continue; // if all integrals screened out, skip to next quartet
+
+            num_ints_computed += n1 * n2 * n3 * n4;
 
 #if defined(REPORT_INTEGRAL_TIMINGS)
             timer.stop(0);
@@ -1739,25 +1769,22 @@ std::vector<Matrix> compute_2body_fock_deriv(const BasisSet& obs,
       compute_shellblock_norm(obs, D);  // matrix of infty-norms of shell blocks
 
   auto fock_precision = precision;
-  // engine precision controls primitive truncation, assume worst-case scenario
-  // (all primitive combinations add up constructively)
+  // standard approach is to omit *contributions* to the Fock matrix smaller than fock_precision ... this relies on massive amount of error cancellation
   auto max_nprim = obs.max_nprim();
-  auto max_nprim4 = max_nprim * max_nprim * max_nprim * max_nprim;
-  auto engine_precision = std::min(fock_precision / D_shblk_norm.maxCoeff(),
-                                   std::numeric_limits<double>::epsilon()) /
-                          max_nprim4;
+  auto needed_engine_precision = (fock_precision / D_shblk_norm.maxCoeff());
+  assert(needed_engine_precision > max_engine_precision &&
+         "using precomputed shell pair data limits the max engine precision"
+         " ... make max_engine_precision smaller and recompile");
 
   // construct the 2-electron repulsion integrals engine pool
   using libint2::Engine;
   std::vector<Engine> engines(nthreads);
   engines[0] =
       Engine(Operator::coulomb, obs.max_nprim(), obs.max_l(), deriv_order);
-  engines[0].set_precision(engine_precision);  // shellset-dependent precision
-                                               // control will likely break
-                                               // positive definiteness
-                                               // stick with this simple recipe
+  engines[0].set(screening_method);
+  engines[0].set_precision(needed_engine_precision);  // N.B. precision will be adjusted for each shellset
   std::cout << "compute_2body_fock:precision = " << precision << std::endl;
-  std::cout << "Engine::precision = " << engines[0].precision() << std::endl;
+  std::cout << "will set Engine::precision as low as = " << engines[0].precision() << std::endl;
   for (size_t i = 1; i != nthreads; ++i) {
     engines[i] = engines[0];
   }
@@ -1877,6 +1904,8 @@ std::vector<Matrix> compute_2body_fock_deriv(const BasisSet& obs,
             timer.start(0);
 #endif
 
+            // vary precision for each shellset to guarantee precision of the contribution to the Fock matrix
+            engine.set_precision(Dnorm1234 != 0. ? fock_precision / Dnorm1234 : needed_engine_precision);
             engine.compute2<Operator::coulomb, BraKet::xx_xx, deriv_order>(
                 obs[s1], obs[s2], obs[s3], obs[s4]);
             if (buf[0] == nullptr)
@@ -2001,10 +2030,7 @@ Matrix compute_2body_fock_general(const BasisSet& obs, const Matrix& D,
   engines[0] = Engine(libint2::Operator::coulomb,
                       std::max(obs.max_nprim(), D_bs.max_nprim()),
                       std::max(obs.max_l(), D_bs.max_l()), 0);
-  engines[0].set_precision(precision);  // shellset-dependent precision control
-                                        // will likely break positive
-                                        // definiteness
-                                        // stick with this simple recipe
+  engines[0].set_precision(precision);
   for (size_t i = 1; i != nthreads; ++i) {
     engines[i] = engines[0];
   }

--- a/tests/hartree-fock/hartree-fock++.cc
+++ b/tests/hartree-fock/hartree-fock++.cc
@@ -1375,12 +1375,13 @@ compute_shellpairs(const BasisSet& bs1,
   }
   shellpair_data_t spdata(splist.size());
   auto make_spdata = [&](int thread_id) {
-    auto schwarz_factor_evaluator = [engine = &engines[thread_id]](const Shell& s1, size_t p1, const Shell& s2, size_t p2) -> double {
-      auto& buf = engine->results();
+    auto schwarz_factor_evaluator = [&](const Shell& s1, size_t p1, const Shell& s2, size_t p2) -> double {
+      auto& engine = engines[thread_id];
+      auto& buf = engine.results();
       auto ps1 = s1.extract_primitive(p1, false);
       auto ps2 = s2.extract_primitive(p2, false);
       const auto n12 = ps1.size() * ps2.size();
-      engine->compute(ps1, ps2, ps1, ps2);
+      engine.compute(ps1, ps2, ps1, ps2);
       if (buf[0]) {
         Eigen::Map<const Matrix> buf_mat(buf[0], n12, n12);
         auto norm2 = screening_method == ScreeningMethod::SchwarzInf ? buf_mat.lpNorm<Eigen::Infinity>() : buf_mat.norm();

--- a/tests/unit/test-precision.cc
+++ b/tests/unit/test-precision.cc
@@ -62,3 +62,135 @@ TEST_CASE("ERI reference values", "[2-body][precision]") {
 }
 #endif  // LIBINT_HAS_MPFR
 
+#if defined(LIBINT2_SUPPORT_ERI)
+TEST_CASE("2-body integrals precision", "[2-body][precision]") {
+  using namespace libint2;
+
+  const auto original_default_screening_method = libint2::default_screening_method();
+  libint2::default_screening_method(libint2::ScreeningMethod::Conservative);
+
+  const auto ry = 4.0;
+  const auto rz = 20.0;
+  const std::string obs_name = "sto-3g";
+  const std::string dfbs_name = "cc-pvdz";
+//  const auto ry = 5.0;
+//  const auto rz = 40.0;
+//  const std::string obs_name = "cc-pvtz";
+//  const std::string dfbs_name = "cc-pvqz-ri";
+  std::stringstream sstr;
+  sstr << "3\n\nNe 0 0 0\nNe 0 0 " << rz << "\nNe 0 " << ry << " 0\n";
+  auto atoms = libint2::read_dotxyz(sstr);
+  BasisSet obs(obs_name, atoms);
+  BasisSet dfbs(dfbs_name, atoms);
+  const auto max_nprim = std::max(obs.max_nprim(), dfbs.max_nprim());
+  const auto max_l = std::max(obs.max_l(), dfbs.max_l());
+
+  for (auto eps: {1e-8, 1e-10, 1e-12, 1e-14, 1e-16}) {
+    for (auto oper : {Operator::coulomb}) {
+      for (auto c : {2, 3, 4}) {
+#if defined(LIBINT2_SUPPORT_ERI2)
+        if (max_l > LIBINT2_MAX_AM_2eri) continue;
+#else
+        if (c == 2) continue;
+#endif
+#if defined(LIBINT2_SUPPORT_ERI3)
+        if (max_l > LIBINT2_MAX_AM_3eri) continue;
+#else
+        if (c == 3) continue;
+#endif
+#if defined(LIBINT2_SUPPORT_ERI)
+        if (max_l > LIBINT2_MAX_AM_eri) continue;
+#else
+        if (c == 4) continue;
+#endif
+
+        auto bases = (c == 4) ? std::vector<BasisSet>{obs, obs, obs, obs}
+                              : ((c == 3) ? std::vector<BasisSet>{dfbs, obs, obs}
+                                          : std::vector<BasisSet>{dfbs, dfbs});
+
+        auto braket = (c == 4)
+                          ? BraKet::xx_xx
+                          : ((c == 3) ? BraKet::xs_xx : BraKet::xs_xs);
+
+        Engine ref_engine(oper, max_nprim, max_l, 0); ref_engine.set_precision(0.0); ref_engine.set(braket);
+        Engine eps_engine(oper, max_nprim, max_l, 0); eps_engine.set_precision(eps); eps_engine.set(braket);
+
+        auto test = [&ref_engine, &eps_engine](const std::vector<const Shell*>& shells, double precision) {
+          const auto c = shells.size();
+          assert(c == 4 || c == 3 || c == 2);
+
+          const auto ref_ints =
+              (c == 4)
+                  ? ref_engine.compute(*shells[0], *shells[1], *shells[2],
+                                       *shells[3])
+                  : ((c == 3)
+                         ? ref_engine.compute(*shells[0], *shells[1], *shells[2])
+                         : ref_engine.compute(*shells[0], *shells[1]));
+          assert(ref_ints[0] != nullptr);
+
+          const auto eps_ints =
+              (c == 4)
+                  ? eps_engine.compute(*shells[0], *shells[1], *shells[2],
+                                       *shells[3])
+                  : ((c == 3)
+                         ? eps_engine.compute(*shells[0], *shells[1], *shells[2])
+                         : eps_engine.compute(*shells[0], *shells[1]));
+
+          const auto nf = std::accumulate(shells.begin(), shells.end(), 1, [](int nf, const Shell* shell_ptr) {
+            return nf * shell_ptr->size();
+          });
+
+          auto max_engine_screening_error = 0.;
+          bool engine_precision_too_low = false;
+          const auto max_allowed_exceening_error_factor = 2;
+          for (auto f = 0; f != nf; ++f) {
+            auto &ref_v = ref_ints[0][f];
+            const auto engine_screening_error =
+                (eps_ints[0] != nullptr) ? std::abs(eps_ints[0][f] - ref_v)
+                                         : std::abs(ref_v);
+            CHECK(engine_screening_error <=
+                  max_allowed_exceening_error_factor * precision);
+            if (engine_screening_error > precision) {
+              max_engine_screening_error =
+                  std::max(engine_screening_error, max_engine_screening_error);
+            }
+            if (engine_screening_error >
+                max_allowed_exceening_error_factor * precision) {
+              engine_precision_too_low = true;
+            }
+          }
+        };
+
+        std::vector<const Shell*> shells(c);
+          for(auto&& sh0: bases[0]) {
+            shells[0] = &sh0;
+            for(auto&& sh1: bases[0]) {
+              shells[1] = &sh1;
+              if (c>2) {
+              for(auto&& sh2: bases[2]) {
+                shells[2] = &sh2;
+                if (c>3) {
+                  for (auto&& sh3 : bases[3]) {
+                    shells[3] = &sh3;
+                    test(shells, eps);
+                  }
+                }
+                else {
+                  test(shells, eps);
+                }
+              }
+            } else {
+              test(shells, eps);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  libint2::default_screening_method(original_default_screening_method);
+
+}
+#endif // defined(LIBINT2_SUPPORT_ERI)
+
+


### PR DESCRIPTION
standard screening method can significantly overestimate precision of L!=0 integrals (by several orders of magnitude). new "conservative" method overestimates it by must smaller amount. For specific operator type it is also possible to use schwarz bounds to guarantee precision.