### PR TITLE
improvements related to `throw`

### DIFF
--- a/include/libint2/chemistry/sto3g_atomic_density.h
+++ b/include/libint2/chemistry/sto3g_atomic_density.h
@@ -70,7 +70,7 @@ inline size_t sto3g_num_ao(size_t Z) {
   else if (Z <= 53)  // Y - I
     nao = 27;
   else
-    throw "STO-3G basis is not defined for elements with Z > 53";
+    throw std::invalid_argument{"STO-3G basis is not defined for elements with Z > 53"};
   return nao;
 }
 

--- a/include/libint2/lcao/1body.h
+++ b/include/libint2/lcao/1body.h
@@ -797,7 +797,7 @@ std::vector<libint2::Atom> read_geometry(const std::string& filename) {
   if (filename.rfind(".xyz") != std::string::npos)
     return libint2::read_dotxyz(iss);
   else
-    throw "only .xyz files are accepted";
+    throw std::invalid_argument{"only .xyz files are accepted"};
 }
 
 // computes Superposition-Of-libint2::Atomic-Densities guess for the molecular density

--- a/include/libint2/shell.h
+++ b/include/libint2/shell.h
@@ -194,7 +194,7 @@ namespace libint2 {
           case 'X': return 17;
           case 'Y': return 18;
           case 'Z': return 19;
-          default: throw "invalid angular momentum label";
+          default: throw std::invalid_argument{"invalid angular momentum label"};
         }
       }
 

--- a/src/bin/libint/exception.h
+++ b/src/bin/libint/exception.h
@@ -53,7 +53,7 @@ namespace libint2 {
   public:
     VertexAlreadyOnStack(const SafePtr<DGVertex>& vertex) :
       logic_error("DirectedGraph -- vertex already on stack"), vertex_(vertex) {}
-    ~VertexAlreadyOnStack() throw() {}
+    ~VertexAlreadyOnStack() noexcept {}
 
     SafePtr<DGVertex> vertex() const { return vertex_; }
 
@@ -70,7 +70,7 @@ namespace libint2 {
   public:
     CannotPerformOperation(const std::string& msg) :
       logic_error(msg) {}
-    virtual ~CannotPerformOperation() throw() {}
+    virtual ~CannotPerformOperation() noexcept {}
   };
 
   /// This exception used to indicate that some property is not set

--- a/tests/hartree-fock/hartree-fock++.cc
+++ b/tests/hartree-fock/hartree-fock++.cc
@@ -882,7 +882,7 @@ std::vector<Atom> read_geometry(const std::string& filename) {
   if (filename.rfind(".xyz") != std::string::npos)
     return libint2::read_dotxyz(iss);
   else
-    throw "only .xyz files are accepted";
+    throw std::invalid_argument{"only .xyz files are accepted"};
 }
 
 // computes Superposition-Of-Atomic-Densities guess for the molecular density

--- a/tests/hartree-fock/hartree-fock.cc
+++ b/tests/hartree-fock/hartree-fock.cc
@@ -445,7 +445,7 @@ std::vector<libint2::Shell> make_sto3g_basis(const std::vector<Atom>& atoms) {
         break;
 
       default:
-        throw "do not know STO-3G basis for this Z";
+        throw std::invalid_argument{"do not know STO-3G basis for this Z"};
     }
 
   }
@@ -501,7 +501,7 @@ Matrix compute_soad(const std::vector<Atom>& atoms) {
     else if (Z <= 10) // Li - Ne
       nao += 5;
     else
-      throw "SOAD with Z > 10 is not yet supported";
+      throw std::invalid_argument{"SOAD with Z > 10 is not yet supported"};
   }
 
   // compute the minimal basis density


### PR DESCRIPTION
- refactor: use `noexcept` specifier  
  `throw` for dynamic exception specification was deprecated
- fix: throw appropriate exceptions

