### PR TITLE
fix ngroupdiis initialization

### DIFF
--- a/include/libint2/diis.h
+++ b/include/libint2/diis.h
@@ -162,7 +162,7 @@ namespace libint2 {
              error_(0), errorset_(false),
              start(strt), ndiis(ndi),
              iter(0), ngroup(ngr),
-             ngroupdiis(ngr),
+             ngroupdiis(ngrdiis),
              damping_factor(dmp),
              mixing_fraction(mf)
            {


### PR DESCRIPTION
Variable ngroupdiis was incorrectly initialized with ngr instead of ngrdiis.