### PR TITLE
Memory leak in simplified fock routine

### DIFF
--- a/tests/hartree-fock/hartree-fock.cc
+++ b/tests/hartree-fock/hartree-fock.cc
@@ -651,6 +651,9 @@ Matrix compute_2body_fock_simple(const std::vector<libint2::Shell>& shells,
           // exchange contribution to the Fock matrix is from {s1,s3,s2,s4} integrals
           engine.compute(shells[s1], shells[s3], shells[s2], shells[s4]);
           const auto* buf_1324 = buf[0];
+          if (buf_1234 == nullptr)
+            continue; // if all integrals screened out, skip to next quartet
+
 
           for(auto f1=0, f1324=0; f1!=n1; ++f1) {
             const auto bf1 = f1 + bf1_first;

--- a/tests/hartree-fock/hartree-fock.cc
+++ b/tests/hartree-fock/hartree-fock.cc
@@ -651,7 +651,7 @@ Matrix compute_2body_fock_simple(const std::vector<libint2::Shell>& shells,
           // exchange contribution to the Fock matrix is from {s1,s3,s2,s4} integrals
           engine.compute(shells[s1], shells[s3], shells[s2], shells[s4]);
           const auto* buf_1324 = buf[0];
-          if (buf_1234 == nullptr)
+          if (buf_1324 == nullptr)
             continue; // if all integrals screened out, skip to next quartet
 
 


### PR DESCRIPTION
compute_2body_fock_simple currently contains a memory leak: buf_1324 can be null if all integrals are screened out. I added the same check that is currently being used for buf_1234 to avoid segfaults.

I produced a segfault by running Hartree Fock with compute_2body_fock_simple with sto-3g.