### PR TITLE
update pybind11, confirmed fixes CI Mac

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,20 +1,41 @@
-cmake_minimum_required(VERSION 3.12)
+if (CMAKE_HOST_WIN32)
+    cmake_minimum_required(VERSION 3.21)
+else()
+    cmake_minimum_required(VERSION 3.16)
+endif()
+cmake_policy(SET CMP0079 NEW)
 
 project(libint2-python)
 
-set(CMAKE_CXX_STANDARD 17)
-add_compile_options(-Wall)
+if (NOT TARGET Python::Module)
+    find_package(Python COMPONENTS Interpreter Development REQUIRED)
+endif()
 
-include(FetchContent)
+find_package(pybind11 2.6.0 CONFIG)
+if (NOT TARGET pybind11::pybind11)
+    message(STATUS "Suitable pybind11 could not be located, building pybind11 instead.")
 
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY      https://github.com/ValeevGroup/pybind11.git
-  GIT_TAG             80d452484c5409444b0ec19383faa84bb7a4d351 # v2.4.3
-  )
-FetchContent_MakeAvailable(pybind11)
+    # [LAB May 2023] For a long time this was fixed at v2.4.3 from a Valeev group clone.
+    #  * recently noticed that C++17 is not getting processed right for this version (at least with the Ubuntu GHA setup)
+    #  * so bumping the backup tag to v2.6.0 (c.2021). the v2.4.3 could probably be revived if needed.
+    include(FetchContent)
+    FetchContent_Declare(
+      pybind11
+      GIT_REPOSITORY https://github.com/pybind/pybind11.git
+      GIT_TAG        v2.6.0  # sync below!
+      # GIT_REPOSITORY      https://github.com/ValeevGroup/pybind11.git
+      # GIT_TAG             80d452484c5409444b0ec19383faa84bb7a4d351  # v2.4.3
+      # FIND_PACKAGE_ARGS 2.4.3 CONFIG  # CMake 3.24 integrates find_package() call above into FC_Declare
+      )
 
-#find_package(Eigen3 3.3 REQUIRED)
+    FetchContent_MakeAvailable(pybind11)
+    set(pybind11_VERSION "2.6.0")  # getting the fetched version isn't reliable from ${CMAKE_PROJECT_VERSION}), so sync explicitly from tag above
+endif()
+
+if (pybind11_VERSION VERSION_LESS_EQUAL 2.5.0)
+    # remove after minimum pb11 advances beyond v2.5.0 and let cxx_std_17 below do the work
+    set(CMAKE_CXX_STANDARD 17)
+endif()
 
 pybind11_add_module(
   libint2-python MODULE
@@ -22,6 +43,18 @@ pybind11_add_module(
   src/libint2/libint2.cc
   src/libint2/engine.cc
   )
+
+target_compile_features(libint2-python PRIVATE "cxx_std_17")
+
+if (pybind11_VERSION VERSION_GREATER_EQUAL 2.7.0)
+    # suppress error in L2
+    # * https://github.com/pybind/pybind11/pull/2919
+    target_compile_definitions(libint2-python PRIVATE NDEBUG=1)
+endif()
+
+add_compile_options(-Wall)
+
+#find_package(Eigen3 3.3 REQUIRED)
 
 set_target_properties(
   libint2-python
@@ -50,14 +83,14 @@ configure_file(setup.py.in ${PROJECT_BINARY_DIR}/setup.py)
 add_custom_target(
   libint2-python-test
   DEPENDS libint2-python
-  COMMAND ${PYTHON_EXECUTABLE} -m setup test
+  COMMAND ${Python_EXECUTABLE} -m setup test
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   )
 
 add_custom_target(
   libint2-python-wheel
   DEPENDS libint2-python
-  COMMAND ${PYTHON_EXECUTABLE} -m setup bdist_wheel
+  COMMAND ${Python_EXECUTABLE} -m setup bdist_wheel
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   )
 
@@ -66,6 +99,6 @@ enable_testing()
 # add the executable
 add_test(
   NAME libint2-python
-  COMMAND ${PYTHON_EXECUTABLE} -m setup test
+  COMMAND ${Python_EXECUTABLE} -m setup test
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   )


### PR DESCRIPTION
- [x] Switch to new scheme for Python detection available for cmake >=3.15 and recc. by pb11: https://pybind11.readthedocs.io/en/stable/compiling.html?highlight=pybind11_nopython#findpython-mode . Note that all cmake variables go from `PYTHON_` to `Python_`
- [x] Adds flexibility in pb11 detection in that it looks for a prebuilt before invoking FetchContent.
- [x] Updates the FetchContent target from a local 2.4.3 to an upstream 2.6
- [x] Added a flag to allow the pylibint2 tests to pass with pb11 >=2.7.0