### PR TITLE
gss/sss (solid harmonic ordering) runtime switchable

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -162,6 +162,7 @@ jobs:
     # * turn off generator testing (comment out "make check" and "stdtests.pl" lines)
     # * suppress last two (test library and bindings) steps ("if: false")
     needs: build_repo
+    if: always() && (needs.build_repo.steps.skip_check.outputs.should_skip != 'true')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -113,7 +113,7 @@ jobs:
         tar -xzf ../compiler/libint-2*.tgz
         cd libint-2*
         echo "LIBINT_EXPORTED_DIR=`pwd`" >> $GITHUB_ENV
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPYTHON_EXECUTABLE=`which python3` $BUILD_CONFIG
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_CONFIG
         cmake --build build --target check
         cmake --build build --target install
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 #env:
 
 jobs:
-  build:
+  build_repo:
     strategy:
       fail-fast: false
       matrix:
@@ -13,7 +13,7 @@ jobs:
         os : [ macos-latest, ubuntu-20.04 ]
         include:
           - os: ubuntu-20.04
-            cxx: /usr/bin/g++-9
+            cxx: g++-10
           - os: macos-latest
             cxx: clang++
 
@@ -65,8 +65,8 @@ jobs:
       if: ${{ steps.skip_check.outputs.should_skip != 'true' && matrix.os == 'ubuntu-20.04' }}
       run: |
         sudo apt-get update
-        sudo apt-get install ninja-build g++-9 gfortran-9 liblapack-dev libboost-dev libeigen3-dev ccache python3-numpy python3-scipy
-        echo "FC=/usr/bin/gfortran-9" >> $GITHUB_ENV
+        sudo apt-get install ninja-build g++-10 gfortran-10 liblapack-dev libboost-dev libeigen3-dev ccache python3-numpy python3-scipy
+        echo "FC=/usr/bin/gfortran-10" >> $GITHUB_ENV
         echo "EIGEN3_INCLUDE_DIR=/usr/include/eigen3" >> $GITHUB_ENV
 
     - name: Prepare ccache timestamp
@@ -104,6 +104,16 @@ jobs:
         make check
         cd src/bin/test_eri && ./stdtests.pl && cd ../../..
         make export
+        echo "ARTIFACT=`ls -1 libint*tgz`" >> $GITHUB_ENV
+
+    - name: Archive Library Tarball
+      if: ${{ steps.skip_check.outputs.should_skip != 'true' && matrix.build_type == 'Release'}}
+      uses: actions/upload-artifact@v3
+      with:
+        if-no-files-found: error
+        name: ${{ runner.os }}-${{ matrix.cxx }}
+        path: ${{github.workspace}}/build/compiler/${{ env.ARTIFACT }}
+        retention-days: 1
 
     - name: Build+test+install Libint library
       if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
@@ -145,4 +155,131 @@ jobs:
         cmake --build . --target libint2-python
         cmake --build . --target libint2-python-test
 
+  build_export:
+    # to debug the second stage, it is handy to short-circuit the first stage down to ~6 minutes:
+    # * run only the Linux/Release (remove items from matrix.build_type and matrix.os)
+    # * don't generate any derivative ints (edit CPPFLAGS)
+    # * turn off generator testing (comment out "make check" and "stdtests.pl" lines)
+    # * suppress last two (test library and bindings) steps ("if: false")
+    needs: build_repo
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - runs-on: ubuntu-latest
+            lane: ubuntu-gnu
+            libargs: >
+              -DBUILD_SHARED_LIBS=ON
+            testargs: ""
+            # note full paths depend on setup-miniconda:
+            # * Miniforge is miniconda3 vs. Miniconda is miniconda
+
+          - runs-on: macos-latest
+            lane: macos-clang
+            libargs: >
+              -DBUILD_SHARED_LIBS=ON
+            testargs: ""
+
+          - runs-on: ubuntu-latest
+            lane: ubuntu-intel
+            libargs: >
+              -DCMAKE_CXX_COMPILER=icpx
+              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/test --sysroot=/usr/share/miniconda3/envs/test/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
+              # flags are long-form of below (envvars not available at spinup)
+              # -DCMAKE_CXX_FLAGS="--gcc-toolchain=${CONDA_PREFIX} --sysroot=${CONDA_PREFIX}/${HOST}/sysroot -target ${HOST}"
+            testargs: >
+              -DCMAKE_CXX_COMPILER=icpx
+              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/test --sysroot=/usr/share/miniconda3/envs/test/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
+
+    name: "Export • ${{ matrix.cfg.lane }} • ${{ matrix.cfg.libargs }}"
+    runs-on: ${{ matrix.cfg.runs-on }}
+
+    steps:
+    # Note we're not checking out the repo. All src from Linux tarball generated above.
+
+    - name: Write a Conda Env File
+      shell: bash -l {0}
+      run: |
+        cat > export.yaml <<EOF
+        name: test
+        channels:
+          - conda-forge
+        dependencies:
+          - cmake
+          - ninja
+          - cxx-compiler
+          - python
+          - boost
+          - eigen
+          - numpy
+          - scipy
+          - pybind11
+          #- dpcpp_linux-64
+        EOF
+        if [[ "${{ matrix.cfg.lane }}" == "ubuntu-intel" ]]; then
+          sed -i "s/#- dpcpp_linux-64/- dpcpp_linux-64/g" export.yaml
+        fi
+        cat export.yaml
+
+    - name: Create Conda Environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniforge-variant: Mambaforge
+        use-mamba: true
+        python-version: "3.9"
+        activate-environment: test
+        channels: conda-forge
+        environment-file: export.yaml
+        show-channel-urls: true
+
+    - name: Environment Information
+      shell: bash -l {0}
+      run: |
+        conda info
+        conda list
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: Linux-g++-10
+
+    - name: Extract, Build, Install Libint Library
+      shell: bash -l {0}
+      run: |
+        tar -zxf libint*tgz
+        mkdir libint && mv libint-2*/* libint/ && cd libint/
+        cmake \
+          -S. \
+          -Bbuild \
+          -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/installed" \
+          -DCMAKE_CXX_COMPILER=${CXX} \
+          -DLIBINT2_PYTHON=ON \
+          -DCMAKE_PREFIX_PATH="${CONDA_PREFIX}" \
+          ${{ matrix.cfg.libargs }}
+        cmake --build build --target install libint2-python-test
+
+    - name: Test Installed Libint library
+      shell: bash -l {0}
+      run: |
+        mkdir test_installed_library && cd test_installed_library
+        cat > CMakeLists.txt <<EOF
+        cmake_minimum_required(VERSION 3.16)
+        project(hf++)
+        find_package(Libint2 2.7.2 REQUIRED COMPONENTS eri_c4_d0_l2 CXX_ho)
+        get_target_property(_l2_maxam Libint2::int2 Libint2_MAX_AM_ERI)
+        message("Libint2_MAX_AM_ERI \${_l2_maxam}")
+        find_package(Threads)  # clang does not autolink threads even though we are using std::thread
+        add_executable(hf++ EXCLUDE_FROM_ALL "../libint/tests/hartree-fock/hartree-fock++.cc")
+        target_link_libraries(hf++ Libint2::cxx Threads::Threads)
+        EOF
+        cmake -S . -B build -DCMAKE_PREFIX_PATH="${{github.workspace}}/installed" ${{ matrix.cfg.testargs }}
+        cmake --build build --target hf++
+        ./build/hf++ ../libint/tests/hartree-fock/h2o_rotated.xyz | python ../libint/tests/hartree-fock/hartree-fock++-validate.py ../libint/MakeVars.features
+
+    - name: Build (again) & Test Python bindings
+      shell: bash -l {0}
+      working-directory: ${{github.workspace}}/libint/python
+      run: |
+        cmake . -D LIBINT2_PYTHON=ON -D CMAKE_PREFIX_PATH="${{github.workspace}}/installed" ${{ matrix.cfg.testargs }}
+        cmake --build . --target libint2-python
+        cmake --build . --target libint2-python-test
 

--- a/INSTALL
+++ b/INSTALL
@@ -26,7 +26,7 @@ then either choose path a or b:
 Building the Python module
 ---------------------------
 Configure libint (Step 2) with `--enable-eri2 --enable-eri3`, export (Step 3b), untar exported archive:
- $ cmake -DPYTHON_EXECUTABLE=`which python3` -DLIBINT2_PYTHON=ON -DCMAKE_PREFIX_PATH=$EIGEN_INSTALL_PATH -DCMAKE_INSTALL_PREFIX=<install-path> .
+ $ cmake -DPython_EXECUTABLE=`which python3` -DLIBINT2_PYTHON=ON -DCMAKE_PREFIX_PATH=$EIGEN_INSTALL_PATH -DCMAKE_INSTALL_PREFIX=<install-path> .
  $ cd python
  $ make
  $ cd .. && make install

--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -480,6 +480,11 @@ configure_file(
         @ONLY
 )
 
+# In the future CMake switchover, configuration.h/cc define a string summary of capabilities. @ONLY is maximally deferred in case config2 changes the
+#   summary (as it used to when LIBINT_SHGSHELL_ORDERING was library-config-time selected).
+#configure_file(${PROJECT_SOURCE_DIR}/include/libint2/util/configuration.h.cmake.in ${PROJECT_BINARY_DIR}/include/libint2/util/configuration.h @ONLY)
+configure_file(src/configuration.cc.cmake.in ${PROJECT_BINARY_DIR}/src/configuration.cc @ONLY)
+
 configure_file(
         include/libint2/basis.h.in
         ${PROJECT_BINARY_DIR}/include/libint2/basis.h

--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -49,6 +49,7 @@ endif(ENABLE_FORTRAN)
 # these are known orderings, must match config.h
 set(LIBINT_SHGSHELL_ORDERING_STANDARD 1)
 set(LIBINT_SHGSHELL_ORDERING_GAUSSIAN 2)
+# August 2023: the following variable has an effect on `INT_SOLIDHARMINDEX(l, m)` but otherwise the choice can be deferred to runtime.
 set(LIBINT2_SHGAUSS_ORDERING "standard" CACHE STRING "Use one of the following known orderings for shells of solid harmonic Gaussians:
   standard -- standard ordering (-l, -l+1 ... l)
   gaussian -- the Gaussian ordering (0, 1, -1, 2, -2, ... l, -l)

--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.8) # introduced C++ standards as features
+cmake_minimum_required(VERSION 3.16)  # 3.15: new Python detection; 3.16 to make the final leap
+                                      # 3.8: introduced C++ standards as features
+cmake_policy(SET CMP0079 NEW)
 
 project(Libint LANGUAGES CXX C)
 
@@ -149,12 +151,16 @@ if (NOT LIBINT_HAS_SYSTEM_BOOST_PREPROCESSOR_VARIADICS OR LIBINT_USE_BUNDLED_BOO
     endif()
 endif()
 
-# Python is optional, unless ...
-if (ENABLE_FORTRAN)  # ... need fortran
-    find_package(PythonInterp REQUIRED)
-else(ENABLE_FORTRAN)
-    find_package(PythonInterp)
-endif(ENABLE_FORTRAN)
+# Python is optionally used for testing.
+# * But for Fortran, it's additionally required for preprocessing.
+# * And for Python bindings, it's required along with its headers.
+if (LIBINT2_PYTHON)
+    find_package(Python COMPONENTS Interpreter Development REQUIRED)
+elseif (ENABLE_FORTRAN)
+    find_package(Python COMPONENTS Interpreter REQUIRED)
+else()
+    find_package(Python COMPONENTS Interpreter)
+endif()
 
 # Set install paths ====================================================================================================
 
@@ -349,14 +355,14 @@ if (LIBINT_HAS_CXX_API)
     target_link_libraries(hf-libint2 libint2_cxx)
     add_test(libint2/hf/build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target hf-libint2)
     set_tests_properties(libint2/hf/build PROPERTIES FIXTURES_SETUP LIBINT2_HFTEST_EXEC)
-    if (PYTHONINTERP_FOUND)
+    if (Python_Interpreter_FOUND)
         add_test(NAME libint2/hf/run
                  COMMAND ${CMAKE_COMMAND}
                  -DtestName=hf-libint2
                  -DfileName=hartree-fock
                  -DtestArgs=${PROJECT_SOURCE_DIR}/tests/hartree-fock/h2o.xyz
                  -DsrcDir=${PROJECT_SOURCE_DIR}
-                 -DpythonExec=${PYTHON_EXECUTABLE}
+                 -DpythonExec=${Python_EXECUTABLE}
                  -P ${PROJECT_SOURCE_DIR}/cmake/hftest.cmake)
     else()
         add_test(NAME libint2/hf/run
@@ -370,14 +376,14 @@ if (LIBINT_HAS_CXX_API)
     target_link_libraries(hf++-libint2 libint2_cxx Threads::Threads)
     add_test(libint2/hf++/build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target hf++-libint2)
     set_tests_properties(libint2/hf++/build PROPERTIES FIXTURES_SETUP LIBINT2_HFXXTEST_EXEC)
-    if (PYTHONINTERP_FOUND)
+    if (Python_Interpreter_FOUND)
         add_test(NAME libint2/hf++/run
                  COMMAND ${CMAKE_COMMAND}
                  -DtestName=hf++-libint2
                  -DfileName=hartree-fock++
                  -DtestArgs=${PROJECT_SOURCE_DIR}/tests/hartree-fock/h2o_rotated.xyz
                  -DsrcDir=${PROJECT_SOURCE_DIR}
-                 -DpythonExec=${PYTHON_EXECUTABLE}
+                 -DpythonExec=${Python_EXECUTABLE}
                  -P ${PROJECT_SOURCE_DIR}/cmake/hftest.cmake)
     else()
         add_test(NAME libint2/hf++/run
@@ -411,14 +417,14 @@ if (ENABLE_FORTRAN)
 
     # translated Libint_t
     add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/fortran/libint2_types_f.h
-            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/fortran/c_to_f.py ${CMAKE_BINARY_DIR}/fortran/libint2.h.i ${CMAKE_BINARY_DIR}/fortran/libint2_types_f.h Libint_t
+            COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/fortran/c_to_f.py ${CMAKE_BINARY_DIR}/fortran/libint2.h.i ${CMAKE_BINARY_DIR}/fortran/libint2_types_f.h Libint_t
             DEPENDS ${CMAKE_BINARY_DIR}/fortran/libint2.h.i
             COMMENT "Generating libint2_types_f.h"
             )
 
     # extracted defines from libint2_types.h
     add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/fortran/fortran_incldefs.h
-            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/fortran/make_defs.py ${PROJECT_SOURCE_DIR}/include/libint2_types.h ${PROJECT_BINARY_DIR}/fortran/fortran_incldefs.h
+            COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/fortran/make_defs.py ${PROJECT_SOURCE_DIR}/include/libint2_types.h ${PROJECT_BINARY_DIR}/fortran/fortran_incldefs.h
             DEPENDS ${PROJECT_SOURCE_DIR}/include/libint2_types.h
             COMMENT "Generating fortran_incldefs.h"
             )

--- a/include/libint2.h
+++ b/include/libint2.h
@@ -33,6 +33,7 @@
 #include <libint2/util/intrinsic_types.h>
 #include <libint2/util/generated/libint2_params.h>
 #include <libint2/util/generated/libint2_types.h>
+#include <libint2/util/configuration.h>
 
 #if defined(__cplusplus)
 #include <libint2/numeric.h>

--- a/include/libint2/cxxapi.h
+++ b/include/libint2/cxxapi.h
@@ -26,7 +26,7 @@
 # error "Libint2 C++ API requires C++11 support"
 #endif
 
-#include <libint2.h>  // NB this loads libint2/config.h
+#include <libint2.h>  // NB this loads libint2/config.h and libint2/util/configuration.h
 
 #ifdef LIBINT_USER_DEFINED_REAL
 # error "C++11 API does not support with user-defined real types yet; omit --with-real-type when configuring"

--- a/include/libint2/shgshell_ordering.h
+++ b/include/libint2/shgshell_ordering.h
@@ -75,17 +75,17 @@ inline int INT_SOLIDHARMINDEX_GAUSSIAN(int l, int m) {
 #define FOR_SOLIDHARM_GAUSSIAN(l, m) \
   for ((m) = 0; (m) != (l) + 1; (m) = ((m) > 0 ? -(m) : 1 - (m))) {
 
-/// these always-available macros encode orderings assumed by Molden
+/// these always-available macros encode orderings assumed by Molden ... useful for writing Molden-specific code
+/// @note Molden and Gaussian ordering coincide
 
 namespace libint2 {
 inline int INT_SOLIDHARMINDEX_MOLDEN(int l, int m) {
-  return 2 * std::abs(m) + (m > 0 ? -1 : 0);
+  return INT_SOLIDHARMINDEX_GAUSSIAN(l, m);
 }
 }
 
-#define FOR_SOLIDHARM_MOLDEN(l, m) \
-  for ((m) = 0; (m) != (l) + 1; (m) = ((m) > 0 ? -(m) : 1 - (m))) {
-#define END_FOR_SOLIDHARM_MOLDEN }
+#define FOR_SOLIDHARM_MOLDEN(l, m) FOR_SOLIDHARM_GAUSSIAN(l, m)
+#define END_FOR_SOLIDHARM_MOLDEN END_FOR_SOLIDHARM
 
 namespace libint2 {
   LIBINT_DEPRECATED("please use libint2::INT_SOLIDHARMINDEX(libint2::solid_harmonics_ordering(), l, m) instead. Current function returns the standard or gaussian index based on build configuration, not on libint2::set_solid_harmonics_ordering() argument.")
@@ -107,13 +107,13 @@ namespace libint2 {
   }
 }
 
-// continue providing a generic FOR_SOLIDHARM?
-//#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_STANDARD
-//#define FOR_SOLIDHARM FOR_SOLIDHARM_STANDARD
-//#elif LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
-//#define FOR_SOLIDHARM FOR_SOLIDHARM_GAUSSIAN
-//#else
-//#  error "unknown value of macro LIBINT_SHGSHELL_ORDERING"
-//#endif
+// FOR_SOLIDHARM dispatches to the appropriate FOR_SOLIDHARM_ macro
+#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_STANDARD
+#define FOR_SOLIDHARM FOR_SOLIDHARM_STANDARD
+#elif LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
+#define FOR_SOLIDHARM FOR_SOLIDHARM_GAUSSIAN
+#else
+#  error "unknown value of macro LIBINT_SHGSHELL_ORDERING"
+#endif
 
 #endif  // _libint2_src_bin_libint_shgshellordering_h_

--- a/include/libint2/shgshell_ordering.h
+++ b/include/libint2/shgshell_ordering.h
@@ -39,30 +39,22 @@ enum SHGShellOrdering {
 // Macros that define orderings
 //
 
-#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_STANDARD
-
 /* Computes an index to a Cartesian function within a shell given
  * l = total angular momentum
  * m = real solid harmonic index (|m| = the absolute value of the projection of
  * the angular momentum on the z axis) m runs from -l to l
  */
 namespace libint2 {
-inline int INT_SOLIDHARMINDEX(int l, int m) { return m + l; }
+inline int INT_SOLIDHARMINDEX_STANDARD(int l, int m) { return m + l; }
 }
-LIBINT_DEPRECATED("please use libint2::INT_SOLIDHARMINDEX instead")
-inline int INT_SOLIDHARMINDEX(int l, int m) { return libint2::INT_SOLIDHARMINDEX(l, m); }
 
 /* This sets up the above loop over cartesian exponents as follows
  * int m;
- * FOR_SOLIDHARM(l,m)
+ * FOR_SOLIDHARM_STANDARD(l,m)
  * END_FOR_SOLIDHARM
  */
-#define FOR_SOLIDHARM(l, m) for ((m) = -(l); (m) <= (l); ++(m)) {
+#define FOR_SOLIDHARM_STANDARD(l, m) for ((m) = -(l); (m) <= (l); ++(m)) {
 #define END_FOR_SOLIDHARM }
-
-#endif  // Standard ordering
-
-#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
 
 /* Computes an index to a Cartesian function within a shell given
  * l = total angular momentum
@@ -70,23 +62,18 @@ inline int INT_SOLIDHARMINDEX(int l, int m) { return libint2::INT_SOLIDHARMINDEX
  * the angular momentum on the z axis) m runs as 0, +1, -1, +2, -2 ... +l, -l
  */
 namespace libint2 {
-inline int INT_SOLIDHARMINDEX(int l, int m) {
+inline int INT_SOLIDHARMINDEX_GAUSSIAN(int l, int m) {
   return 2 * std::abs(m) + (m > 0 ? -1 : 0);
 }
 }
-LIBINT_DEPRECATED("please use libint2::INT_SOLIDHARMINDEX instead")
-inline int INT_SOLIDHARMINDEX(int l, int m) { return libint2::INT_SOLIDHARMINDEX(l, m); }
 
 /* This sets up the above loop over cartesian exponents as follows
  * int m;
- * FOR_SOLIDHARM(l,m)
+ * FOR_SOLIDHARM_GAUSSIAN(l,m)
  * END_FOR_SOLIDHARM
  */
-#define FOR_SOLIDHARM(l, m) \
+#define FOR_SOLIDHARM_GAUSSIAN(l, m) \
   for ((m) = 0; (m) != (l) + 1; (m) = ((m) > 0 ? -(m) : 1 - (m))) {
-#define END_FOR_SOLIDHARM }
-
-#endif  // Gaussian ordering
 
 /// these always-available macros encode orderings assumed by Molden
 
@@ -95,11 +82,38 @@ inline int INT_SOLIDHARMINDEX_MOLDEN(int l, int m) {
   return 2 * std::abs(m) + (m > 0 ? -1 : 0);
 }
 }
-LIBINT_DEPRECATED("please use libint2::INT_SOLIDHARMINDEX_MOLDEN instead")
-inline int INT_SOLIDHARMINDEX_MOLDEN(int l, int m) { return libint2::INT_SOLIDHARMINDEX_MOLDEN(l, m); }
 
 #define FOR_SOLIDHARM_MOLDEN(l, m) \
   for ((m) = 0; (m) != (l) + 1; (m) = ((m) > 0 ? -(m) : 1 - (m))) {
 #define END_FOR_SOLIDHARM_MOLDEN }
+
+namespace libint2 {
+  LIBINT_DEPRECATED("please use libint2::INT_SOLIDHARMINDEX(libint2::solid_harmonics_ordering(), l, m) instead. Current function returns the standard or gaussian index based on build configuration, not on libint2::set_solid_harmonics_ordering() argument.")
+  inline int INT_SOLIDHARMINDEX(int l, int m) {
+#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_STANDARD
+    return libint2::INT_SOLIDHARMINDEX_STANDARD(l, m);
+#elif LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
+    return libint2::INT_SOLIDHARMINDEX_GAUSSIAN(l, m);
+#else
+#  error "unknown value of macro LIBINT_SHGSHELL_ORDERING"
+#endif
+  }
+
+  inline int INT_SOLIDHARMINDEX(int sho, int l, int m) {
+    if (sho == LIBINT_SHGSHELL_ORDERING_STANDARD)
+      return libint2::INT_SOLIDHARMINDEX_STANDARD(l, m);
+    else
+      return libint2::INT_SOLIDHARMINDEX_GAUSSIAN(l, m);
+  }
+}
+
+// continue providing a generic FOR_SOLIDHARM?
+//#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_STANDARD
+//#define FOR_SOLIDHARM FOR_SOLIDHARM_STANDARD
+//#elif LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
+//#define FOR_SOLIDHARM FOR_SOLIDHARM_GAUSSIAN
+//#else
+//#  error "unknown value of macro LIBINT_SHGSHELL_ORDERING"
+//#endif
 
 #endif  // _libint2_src_bin_libint_shgshellordering_h_

--- a/include/libint2/solidharmonics.h
+++ b/include/libint2/solidharmonics.h
@@ -171,13 +171,19 @@ namespace libint2 {
           const unsigned short ncart = (l_ + 1) * (l_ + 2) / 2;
           std::vector<Real> full_coeff(npure * ncart);
 
-#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_STANDARD
-          for(signed char pure_idx=0, m=-l_; pure_idx!=npure; ++pure_idx, ++m) {
-#elif LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
-          for(signed char pure_idx=0, m=0; pure_idx!=npure; ++pure_idx, m=(m>0?-m:1-m)) {
-#else
-#  error "unknown value of macro LIBINT_SHGSHELL_ORDERING"
-#endif
+          std::vector<int> shg_indices;
+          if (libint2::solid_harmonics_ordering() == libint2::SHGShellOrdering_Standard) {
+            for(signed char pure_idx=0, m=-l_; pure_idx!=npure; ++pure_idx, ++m)
+              shg_indices.push_back(m);
+          } else if (libint2::solid_harmonics_ordering() == libint2::SHGShellOrdering_Gaussian) {
+            for(signed char pure_idx=0, m=0; pure_idx!=npure; ++pure_idx, m=(m>0?-m:1-m))
+              shg_indices.push_back(m);
+          } else {
+            throw std::invalid_argument(std::string("libint2::solid_harmonics_ordering() value not recognized."));
+          }
+
+          for(signed char pure_idx=0; pure_idx!=npure; ++pure_idx) {
+            int m = shg_indices[pure_idx];
             signed char cart_idx = 0;
             signed char lx, ly, lz;
             FOR_CART(lx, ly, lz, l_)

--- a/include/libint2/util/configuration.h
+++ b/include/libint2/util/configuration.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2004-2023 Edward F. Valeev
+ *
+ *  This file is part of Libint.
+ *
+ *  Libint is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Libint is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Libint.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef _libint2_include_libint2_util_configuration_h_
+#define _libint2_include_libint2_util_configuration_h_
+
+/* Runtime accessor for the library configuration:
+   integral derivatives, AM, orderings, etc.
+   @return the semicolon-separated strings from CMake components */
+const char * configuration_accessor();
+
+#ifdef _libint2_src_lib_libint_cxxapi_h_
+#include <string>
+
+namespace libint2 {
+
+  /// Runtime accessor for the library configuration:
+  /// integral derivatives, AM, orderings, etc.
+  /// @return the semicolon-separated strings from CMake components
+  inline std::string configuration_accessor() {
+    std::string components = ::configuration_accessor();
+    return components;
+  }
+}
+#endif /* cxxapi guard */
+
+#endif /* header guard */

--- a/python/src/libint2/libint2.cc
+++ b/python/src/libint2/libint2.cc
@@ -137,6 +137,12 @@ std::vector<double> coeffs_normalized(const Shell &s) {
 
 PYBIND11_MODULE(libint2, m) {
 
+  py::enum_<SHGShellOrdering>(m, "SHGShellOrdering")
+    .value("SHGShellOrdering_Standard", libint2::SHGShellOrdering_Standard)
+    .value("SHGShellOrdering_Gaussian", libint2::SHGShellOrdering_Gaussian)
+    .value("SHGShellOrdering_MOLDEN", libint2::SHGShellOrdering_Gaussian)
+    ;
+
   libint2::initialize();
 
   m.attr("MAX_AM") = LIBINT2_MAX_AM;

--- a/src/bin/libint/build_libint.cc
+++ b/src/bin/libint/build_libint.cc
@@ -366,7 +366,13 @@ build_onebody_1b_1k(std::ostream& os, std::string label, const SafePtr<Compilati
             for(int l=0; l<=MULTIPOLE_MAX_ORDER; ++l) {
               // we iterate over them same way as over solid harmonic Gaussian shells
               int m;
-              FOR_SOLIDHARM(l,m)
+#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_STANDARD
+              FOR_SOLIDHARM_STANDARD(l,m)
+#elif LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
+              FOR_SOLIDHARM_GAUSSIAN(l,m)
+#else
+#  error "unknown value of macro LIBINT_SHGSHELL_ORDERING"
+#endif
                 descrs.push_back(make_descr<OperDescrType>(l,m));
               END_FOR_SOLIDHARM
             }

--- a/src/bin/libint/build_libint.cc
+++ b/src/bin/libint/build_libint.cc
@@ -364,15 +364,9 @@ build_onebody_1b_1k(std::ostream& os, std::string label, const SafePtr<Compilati
             descrs.resize(0);
             // iterate over operators and construct their descriptors
             for(int l=0; l<=MULTIPOLE_MAX_ORDER; ++l) {
-              // we iterate over them same way as over solid harmonic Gaussian shells
+              // we iterate over them using the *standard* solid harmonic Gaussian ordering
               int m;
-#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_STANDARD
               FOR_SOLIDHARM_STANDARD(l,m)
-#elif LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
-              FOR_SOLIDHARM_GAUSSIAN(l,m)
-#else
-#  error "unknown value of macro LIBINT_SHGSHELL_ORDERING"
-#endif
                 descrs.push_back(make_descr<OperDescrType>(l,m));
               END_FOR_SOLIDHARM
             }

--- a/src/lib/MakeRules.in
+++ b/src/lib/MakeRules.in
@@ -14,6 +14,7 @@ export:: source
 	for i in $(LIBSRCDIR)/*.h; do \
 	 $(INSTALL) $(INSTALLLIBOPT) $${i} $(TOPDIR)/$(EXPORTDIR)/include; \
         done
+	$(INSTALL) $(INSTALLLIBOPT) $(SRCTOPDIR)/src/lib/libint/configuration.cc.cmake.in $(TOPDIR)/$(EXPORTDIR)/src/configuration.cc.cmake.in
 
 $(TOPDIR)/lib/$(TARGET): source
 	cd $(LIBSRCLINK); $(MAKE) TO_TOPDIR=$(TO_TOPDIR) TOPDIR=$(TOPOBJDIR) SRCDIR=$(SRCDIR)

--- a/src/lib/libint/configuration.cc.cmake.in
+++ b/src/lib/libint/configuration.cc.cmake.in
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2004-2023 Edward F. Valeev
+ *
+ *  This file is part of Libint.
+ *
+ *  Libint is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Libint is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Libint.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/* Runtime accessor for the library configuration:
+   integral derivatives, AM, orderings, etc.
+   @return the semicolon-separated strings from CMake components */
+const char * configuration_accessor() {
+    //return "@Libint2_CONFIG_COMPONENTS@";
+    return "(nyi)";
+}
+


### PR DESCRIPTION
(in order of decreasing importance)

- [x] add runtime switchable solid harmonic ordering
  - [x] in initialize.h, add setter and accessor so that one can do the below (as psi4 does: https://github.com/psi4/psi4/blob/master/psi4/src/core.cc#L1038) . If SH ordering is never set, default is standard ordering.
  ```
    libint2::initialize();
    libint2::set_solid_harmonics_ordering(libint2::SHGShellOrdering_Gaussian);
  ``` 
  - [x] in shgshell_ordering, inlines for both orderings are now always defined. `INT_SOLIDHARMINDEX(l, m)` with 2 args has been deprecated (throws a warning) but still returns the value as the library was configured at build-time. a new `INT_SOLIDHARMINDEX(sho, l, m)` with 3 args returns the value according to the SH ordering requested in the new 1st arg.
  - [x] in `solidharmonics.h`, generating the indices switches from ifdefs to logic.
* [added 3 Sept] see https://github.com/evaleev/libint/pull/271/commits/05ff2f12e35dbce950cc1faa586e60367385a05e for testing of the runtime switchable SHO functionality.
- [x] the only non-runtime-switchable use of solid harmonics is for generating the multipole ints code in build_libint.cc . we discussed possibly removing that option and settling on STANDARD. but for now to be minimally disruptive, it's still configurable. 
- [x] more migration from `find_package(PythonInterp)` to ` find_package(Python COMPONENTS Interpreter Development)`. Specify directly with `Python_EXECUTABLE`. Hint behavior is complex, as described in https://cmake.org/cmake/help/latest/module/FindPython.html .
- [x] to use the new Python detection, it's recommended to require cmake 3.15+ (https://pybind11.readthedocs.io/en/stable/compiling.html?highlight=pybind11_nopython#findpython-mode). since the final goal is 3.16, I went ahead and bumped it to that.
- [x] add in configuration.h/cc files . at the moment, all this does is add a function `configuration_accessor()` that returns `(nyi)`. this is in preparation for later accessing build configration at runtime.
- [x] expand GHA testing. the first stage `build_repo` (was `build`) remains largely the same except that the `Release` lanes upload a GHA artifact of the exported tarball. in the second stage, the _Linux_ artifact gets downloaded into a fresh environment, and the library is built with gcc and icpx on Linux and clang on Mac. These all use a conda environment for uniformity across platforms. (the first stage is testing homebrew and apt-get.) only the `hf++` test is run. python bindings are built and tested.
- [x] bump GHA Ununtu gcc from 9 to 10


* Note that this snapshot has not been tested against Psi4. At the moment, it's the full #259 implementation that I know to be working.

* Now rebased to master. Please squash PR when merging.
