### PR TITLE
Patch to circumvent #274

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install prerequisite MacOS packages
       if: ${{ steps.skip_check.outputs.should_skip != 'true' && matrix.os == 'macos-latest' }}
       run: |
-        brew install ninja gcc@10 boost eigen bison ccache automake python3 numpy scipy
+        brew install ninja gcc@10 boost eigen bison ccache automake python@3.11 numpy scipy
         echo "FC=/usr/local/bin/gfortran-10" >> $GITHUB_ENV
         echo "EIGEN3_INCLUDE_DIR=/usr/local/include/eigen3" >> $GITHUB_ENV
 


### PR DESCRIPTION
Circumvent issue #274, Python 3.12 incompatibility with Libint. The _reason_ for the incompatibility needs to be diagnosed, but this will prevent tests from failing in the meantime.