### PR TITLE
[ci] hardwire python path in `build_repo`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,6 +38,7 @@ jobs:
         -DMPIEXEC_PREFLAGS='--bind-to;none;--allow-run-as-root'
         -DENABLE_FORTRAN=ON
         -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/library/install
+        -DPython_EXECUTABLE=${{ matrix.os == 'macos-latest' && '/usr/local/Frameworks/Python.framework/Versions/3.11/bin/python3.11' || '/usr/bin/python3.8' }}
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
 


### PR DESCRIPTION
seems that some macOS runners have python 3.12 which gets picked up even though we want 3.11 only; this hardwires python paths, but only in the `build_repo` part of the matrix; `build_export` uses Conda python.