### PR TITLE
fixup `dvi` and `html` builds in `progman`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1117,8 +1117,30 @@ AC_PATH_PROG(PDFLATEX,pdflatex,,$PATH:/usr/local/bin:/opt/local/bin)
 AC_PATH_PROG(PSLATEX,pslatex,,$PATH:/usr/local/bin:/opt/local/bin)
 AC_PATH_PROG(DVIPS,dvips,,$PATH:/usr/local/bin:/opt/local/bin)
 AC_PATH_PROG(LATEX,latex,,$PATH:/usr/local/bin:/opt/local/bin)
-AC_PATH_PROG(LATEX2HTML,latex2html,,$PATH:/usr/local/bin:/opt/local/bin)
 AC_PATH_PROG(BIBTEX,bibtex,,$PATH:/usr/local/bin:/opt/local/bin)
+
+CHECK_FOR_LATEX2HTML=no
+AC_ARG_ENABLE(latex2html,
+AS_HELP_STRING([--enable-latex2html],[Enable detection of latex2html (broken on many platforms, hence disabled by default)]),
+[
+case $enableval in
+  yes)
+    CHECK_FOR_LATEX2HTML=yes
+  ;;
+  no)
+    CHECK_FOR_LATEX2HTML=no
+  ;;
+  *)
+    AC_MSG_ERROR([Invalid value for --enable-latex2html ($enableval)])
+  ;;
+esac
+],[
+    CHECK_FOR_LATEX2HTML=no
+]
+)
+if test "X$CHECK_FOR_LATEX2HTML" = "Xyes" ; then
+  AC_PATH_PROG(LATEX2HTML,latex2html,,$PATH:/usr/local/bin:/opt/local/bin)
+fi
 
 dnl The lack of certain tools is a show stopper
 

--- a/doc/MakeRules.in
+++ b/doc/MakeRules.in
@@ -5,7 +5,7 @@ default:: $(TARGET)
 
 install:: install_target
 
-install_target:: default
+install_target:: $(TARGET)
 	$(INSTALL) $(INSTALLDIROPT) $(DESTDIR)$(docdir)
 	$(LTINST) $(INSTALL) $(INSTALLDOCOPT) $(TARGET) $(DESTDIR)$(docdir)
 
@@ -18,3 +18,5 @@ targetclean:: clean
 
 realclean:: clean
 	-rm -f $(TEXGARBAGE)
+
+.PHONY: dvi html pdf ps install_target default install clean distclean targetclean realclean

--- a/doc/MakeVars.in
+++ b/doc/MakeVars.in
@@ -33,13 +33,12 @@ BIBTEX = @BIBTEX@
 # The document suffix (pdf or ps)
 # Preferentially make pdf manuals, only revert to ps if necessary
 ifdef BIBTEX
+ DOCSUF = dvi
  ifdef PSLATEX
   DOCSUF = ps
-  LATEX = $(PSLATEX)
  endif
  ifdef PDFLATEX
   DOCSUF = pdf
-  LATEX = $(PDFLATEX)
  endif
 endif
 TEXINPUTS = :$(SRCDIR):$(SRCDIR)/..:
@@ -54,4 +53,3 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 docdir=$(prefix)/doc
 includedir=@libintincludedir@
-

--- a/doc/progman/Makefile
+++ b/doc/progman/Makefile
@@ -77,8 +77,8 @@ install-dvi:: dvi
 	TEXINPUTS=$(TEXINPUTS) $(LATEX) $<
 
 ifdef LATEX2HTML
-html:: dvi
-	$(LATEX2HTML) $(TARGETNAME)
+html:: $(SRCDIR)/$(TARGETNAME).tex
+	$(LATEX2HTML) $<
 endif
 
 endif


### PR DESCRIPTION
- building of `dvi` targets was broken
- invocation of `latex2html` updated to expected + fixed-up replay of #305 

resolves https://github.com/evaleev/libint/issues/301