### PR TITLE
full cmake 2/N: integral classes and AM configuration

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,7 +11,7 @@ Following is a brief summary of changes made in each release of Libint.
   - PR #283: bump pybind11 to ValeevGroup/pybind11@v2.11 (HT @asadchev)
   - PR #282: removed obsolete basis files (HT @JonathonMisiewicz)
   - PR #279: fixed error in 1-e erf/erfc integrals (HT @JonathonMisiewicz)
-  - PR @273: support for 1-e (σ·p)V(σ·p) integrals (HT @JonathonMisiewicz)
+  - PR #273: support for 1-e (σ·p)V(σ·p) integrals (HT @JonathonMisiewicz)
   - PR #271: Add `libint2::configuration_accessor` and `libint2::supports` functions. If
     library source is patched, these provide codes for what integrals a library instance can supply. (HT @loriab)
   - PR #271: Small pkgconfig and cmake detection improvements. Enable unity build.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,143 @@ set(pnv libint2) # projectnameversion
 #    -- Build files have been written to: /current/dir/build
 #    >>> cmake --build build --target install
 
+# The Libint build is structured into three parts:
+#
+# * generator/compiler
+#   - (1) build src/bin/libint/ into compiler executable `build_libint`
+#   - pretty quick, runs in parallel
+#   - consumes all the enable/max/opt/orderings integral options
+#   - (2) optionally testable
+# * export
+#   - (3) run `build_libint` to generate library source (C++) files (that upon
+#     compilation can become a Libint2 library) and combine them with other
+#     static source files in src/lib/libint/ and general static files (e.g.,
+#     include/ and docs/) into an independent tarball ready for distribution
+#     (with its own CMake configuration, tests, etc.).
+#   - really slow for non-trivial angular momenta; runs in serial
+#   - consumes no options
+#   - build target `export` to stop after this step and collect source tarball
+# * library
+#   - can be built as a subproject (FetchContent) or completely insulated (bare
+#     ExternalProject; default; -or- a tarball start). For FetchContent, must
+#     build libint-library-export target before library build targets appear
+#   - (4) unpack the export tarball and build the library and install into \<build\>/library-install-stage/
+#   - duration depends on number of integrals requested; runs in parallel
+#   - consumes language-interface and the CMAKE_INSTALL_[DATA|INCLUDE|LIB]DIR paths options
+#   - the default build target includes this final library build
+#   - (5) optionally testable
+#   - (6) install into CMAKE_INSTALL_PREFIX
+#   - (7) optional Python build alongside library or afterwards. Optional testing requires library install
+
+#################################### Guide #####################################
+
+# See INSTALL.md for elaboration of steps above, options below, & translations from libtool.
+
+################################### Options ####################################
+include(options)
+include(GNUInstallDirs)
+include(CTest)
+message(STATUS "Building using CMake ${CMAKE_VERSION} Generator ${CMAKE_GENERATOR}")
+
+
+#  <<<  Which Integrals Classes, Which Derivative Levels  >>>
+
+option_with_default(ENABLE_ONEBODY
+  "Compile with support for up to N-th derivatives of 1-body integrals (-1 for OFF)" 0)
+option_with_default(ENABLE_ERI
+  "Compile with support for up to N-th derivatives of 4-center electron repulsion integrals (-1 for OFF)" 0)
+option_with_default(ENABLE_ERI3
+  "Compile with support for up to N-th derivatives of 3-center electron repulsion integrals (-1 for OFF)" -1)
+option_with_default(ENABLE_ERI2
+  "Compile with support for up to N-th derivatives of 2-center electron repulsion integrals (-1 for OFF)" -1)
+option_with_default(ENABLE_G12
+  "Compile with support for N-th derivatives of MP2-F12 energies with Gaussian factors (-1 for OFF)" -1)
+option_with_default(ENABLE_G12DKH
+  "Compile with support for N-th derivatives of DKH-MP2-F12 energies with Gaussian factors (-1 for OFF)" -1)
+
+option_with_print(DISABLE_ONEBODY_PROPERTY_DERIVS
+  "Disable geometric derivatives of 1-body property integrals (all but overlap, kinetic, elecpot).
+   These derivatives are disabled by default to save compile time. (enable with OFF)
+   Note that the libtool build won't enable this- if forcibly enabled, build_libint balks." ON)
+option_with_print(ENABLE_T1G12_SUPPORT
+  "Enable Ti,G12 integrals when G12 integrals are enabled. Irrelevant when `ENABLE_G12=OFF`. (disable with OFF)" ON)
+
+#  <<<  Ordering Conventions  >>>
+
+option_with_print(ERI3_PURE_SH
+  "Assume the 'unpaired' center of 3-center ERIs will be transformed to pure solid harmonics" OFF)
+option_with_print(ERI2_PURE_SH
+  "Assume the 2-center ERIs will be transformed to pure solid harmonics" OFF)
+
+#  <<<  How High Angular Momentum  >>>
+
+#  example for "semicolon-separated string": `-DENABLE_ERI3=2 -DWITH_ERI3_MAX_AM="5;4;3"`
+
+#  special considerations for high-AM library builds:
+#  * high MAX_AM generates a large number of source files. If unity builds are disabled, more than
+#    ~20k files may require `ulimit -s 65535` for linking the library target on Linux to avert
+#    "ld: Argument list too long".
+#  * Ninja builds use beyond max threads and can run out of memory, resulting in errorless stops or
+#    "CMake Error: Generator: execution of make failed". Throttle it to physical threads with
+#    `export CMAKE_BUILD_PARALLEL_LEVEL=N`.
+
+option_with_default(WITH_MAX_AM
+  "Support Gaussians of angular momentum up to N.
+   Can specify values for each derivative level as a semicolon-separated string.
+   If ERI3 ints are enabled, this option also controls the AM of the paired centers." 4)
+option_with_default(WITH_OPT_AM
+  "Optimize maximally for up to angular momentum N (N <= max-am).
+   Can specify values for each derivative level as a semicolon-separated string. (default: (libint_max_am/2)+1)" -1)
+
+option_with_default(MULTIPOLE_MAX_ORDER
+  "Maximum order of spherical multipole integrals. There is no maximum" 4)
+option_with_default(WITH_ONEBODY_MAX_AM
+  "Support 1-body ints for Gaussians of angular momentum up to N.
+   Can specify values for each derivative level as a semicolon-separated string. (default: max_am)" -1)
+option_with_default(WITH_ONEBODY_OPT_AM
+  "Optimize 1-body ints maximally for up to angular momentum N (N <= max-am).
+   Can specify values for each derivative level as a semicolon-separated string (default: (max_am/2)+1)" -1)
+
+option_with_default(WITH_ERI_MAX_AM
+  "Support 4-center ERIs for Gaussians of angular momentum up to N.
+   Can specify values for each derivative level as a semicolon-separated string. (default: max_am)" -1)
+option_with_default(WITH_ERI_OPT_AM
+  "Optimize 4-center ERIs maximally for up to angular momentum N (N <= max-am).
+   Can specify values for each derivative level as a semicolon-separated string (default: (max_am/2)+1)" -1)
+
+option_with_default(WITH_ERI3_MAX_AM
+  "Support 3-center ERIs for Gaussians of angular momentum up to N.
+   Can specify values for each derivative level as a semicolon-separated string. (default: max_am)
+   This option controls only the single fitting center; the paired centers use WITH_MAX_AM." -1)
+option_with_default(WITH_ERI3_OPT_AM
+  "Optimize 3-center ERIs maximally for up to angular momentum N (N <= max-am).
+   Can specify values for each derivative level as a semicolon-separated string. (default: (max_am/2)+1)" -1)
+
+option_with_default(WITH_ERI2_MAX_AM
+  "Support 2-center ERIs for Gaussians of angular momentum up to N.
+    Can specify values for each derivative level as a semicolon-separated string. (default: max_am)" -1)
+option_with_default(WITH_ERI2_OPT_AM
+  "Optimize 2-center ERIs maximally for up to angular momentum N (N <= max-am).
+   Can specify values for each derivative level as a semicolon-separated string. (default: (max_am/2)+1)" -1)
+
+option_with_default(WITH_G12_MAX_AM
+  "Support integrals for G12 methods of angular momentum up to N. (default: max_am)" -1)
+option_with_default(WITH_G12_OPT_AM
+  "Optimize G12 integrals for up to angular momentum N (N <= max-am). (default: (max_am/2)+1)" -1)
+
+option_with_default(WITH_G12DKH_MAX_AM
+  "Support integrals for relativistic G12 methods of angular momentum up to N. (default: max_am)" -1)
+option_with_default(WITH_G12DKH_OPT_AM
+  "Optimize G12DKH integrals for up to angular momentum N (N <= max-am). (default: (max_am/2)+1)" -1)
+
+booleanize01(ERI3_PURE_SH)
+booleanize01(ERI2_PURE_SH)
+booleanize01(DISABLE_ONEBODY_PROPERTY_DERIVS)
+booleanize01(SUPPORT_T1G12)
+
 ################################## Main Project #################################
+
+configure_file(include/libint2/config.h.cmake.in include/libint2/config.h @ONLY)
 
 # STRICTLY TEMPORARY FOR DEMONSTRATION PURPOSES
 configure_file(src/lib/libint/configuration.cc configuration.cc @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ project(
   Libint2Compiler
   VERSION ${LibintRepository_VERSION}
   DESCRIPTION
-    "Libint: A library for the evaluation of molecular integrals of many-body operators over Gaussian functions"
+    "A library for the evaluation of molecular integrals of many-body operators over Gaussian functions"
   HOMEPAGE_URL "http://libint.valeyev.net"
   LANGUAGES CXX
   )
@@ -36,6 +36,7 @@ set(${PROJECT_NAME}_LICENSE "GPL-3.0 for generator; LGPL-3.0 for generated")
 #   describe`, these are the authoritative version source (formerly in configure.ac)
 set(LIBINT_BUILDID "post999")
 set(LIBINT_SOVERSION "2:3:0")
+set(LIBINT_DOI "10.5281/zenodo.10369117")  # 2.8.0
 
 include(int_versions)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,10 +118,6 @@ option_with_print(ENABLE_T1G12_SUPPORT
 
 #  <<<  Ordering Conventions  >>>
 
-option_with_print(ERI3_PURE_SH
-  "Assume the 'unpaired' center of 3-center ERIs will be transformed to pure solid harmonics" OFF)
-option_with_print(ERI2_PURE_SH
-  "Assume the 2-center ERIs will be transformed to pure solid harmonics" OFF)
 
 #  <<<  How High Angular Momentum  >>>
 
@@ -166,6 +162,8 @@ option_with_default(WITH_ERI3_MAX_AM
 option_with_default(WITH_ERI3_OPT_AM
   "Optimize 3-center ERIs maximally for up to angular momentum N (N <= max-am).
    Can specify values for each derivative level as a semicolon-separated string. (default: (max_am/2)+1)" -1)
+option_with_print(ERI3_PURE_SH
+  "Assume the 'unpaired' center of 3-center ERIs will be transformed to pure solid harmonics" OFF)
 
 option_with_default(WITH_ERI2_MAX_AM
   "Support 2-center ERIs for Gaussians of angular momentum up to N.
@@ -173,6 +171,8 @@ option_with_default(WITH_ERI2_MAX_AM
 option_with_default(WITH_ERI2_OPT_AM
   "Optimize 2-center ERIs maximally for up to angular momentum N (N <= max-am).
    Can specify values for each derivative level as a semicolon-separated string. (default: (max_am/2)+1)" -1)
+option_with_print(ERI2_PURE_SH
+  "Assume the 2-center ERIs will be transformed to pure solid harmonics" OFF)
 
 option_with_default(WITH_G12_MAX_AM
   "Support integrals for G12 methods of angular momentum up to N. (default: max_am)" -1)
@@ -183,6 +183,10 @@ option_with_default(WITH_G12DKH_MAX_AM
   "Support integrals for relativistic G12 methods of angular momentum up to N. (default: max_am)" -1)
 option_with_default(WITH_G12DKH_OPT_AM
   "Optimize G12DKH integrals for up to angular momentum N (N <= max-am). (default: (max_am/2)+1)" -1)
+
+######################## Process & Validate Options ###########################
+include(FeatureSummary)
+include(int_am)
 
 booleanize01(ERI3_PURE_SH)
 booleanize01(ERI2_PURE_SH)
@@ -195,3 +199,7 @@ configure_file(include/libint2/config.h.cmake.in include/libint2/config.h @ONLY)
 
 # STRICTLY TEMPORARY FOR DEMONSTRATION PURPOSES
 configure_file(src/lib/libint/configuration.cc configuration.cc @ONLY)
+
+message("")
+feature_summary(WHAT ENABLED_FEATURES DESCRIPTION "Libint Enabled features:")
+feature_summary(WHAT DISABLED_FEATURES DESCRIPTION "Libint Disabled features:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.19)  # string(json
+cmake_policy(SET CMP0074 NEW)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+    # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
+############################# Version and Metadata #############################
+
+# can't use PROJECT_SOURCE_DIR etc. before project() call
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+include(DynamicVersion)
+dynamic_version(
+  PROJECT_PREFIX Libint2Compiler_
+  GIT_ARCHIVAL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/.git_archival.txt
+  OUTPUT_COMMIT LibintRepository_COMMIT
+  OUTPUT_VERSION LibintRepository_VERSION 
+  OUTPUT_DESCRIBE LibintRepository_DESCRIBE
+  OUTPUT_DISTANCE LibintRepository_DISTANCE
+  )
+
+project(
+  Libint2Compiler
+  VERSION ${LibintRepository_VERSION}
+  DESCRIPTION
+    "Libint: A library for the evaluation of molecular integrals of many-body operators over Gaussian functions"
+  HOMEPAGE_URL "http://libint.valeyev.net"
+  LANGUAGES CXX
+  )
+  # * http://libint.valeyev.net/ redirects to https://github.com/evaleev/libint
+
+set(${PROJECT_NAME}_AUTHORS "Edward F. Valeev")
+set(${PROJECT_NAME}_LICENSE "GPL-3.0 for generator; LGPL-3.0 for generated")
+
+# along with project(... VERSION) above scanned by dynamic_version() from `git
+#   describe`, these are the authoritative version source (formerly in configure.ac)
+set(LIBINT_BUILDID "post999")
+set(LIBINT_SOVERSION "2:3:0")
+
+include(int_versions)
+
+set(L2 Libint2)  # Namespace
+set(pnv libint2) # projectnameversion
+
+################################### Overview ###################################
+
+# CMake build overview:
+#
+#    >>> ls
+#    cmake/  COPYING  src/  tests/  ...
+#    >>> cmake -S. -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=/path/to/install-libint ...
+#    ...
+#    -- Generating done
+#    -- Build files have been written to: /current/dir/build
+#    >>> cmake --build build --target install
+
+################################## Main Project #################################
+
+# STRICTLY TEMPORARY FOR DEMONSTRATION PURPOSES
+configure_file(src/lib/libint/configuration.cc configuration.cc @ONLY)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -130,3 +130,27 @@ Eventually, these will be CMake Components, too.
    bs - library integrals use ordering  bagel    + standard  = bagel
    bo - library integrals use ordering           + orca
 ```
+
+### Interfacing
+
+Eventually (approximately 2.9.0 CMake-based), additional functions will be available to retrive Libint version, commit, and literature citation. Below are outputs at the libtool stage.
+
+```
+auto Mmp = libint2::libint_version();
+printf("Version: Numeric=%s Sortable=%s Commit=%s\n", libint2::libint_version_string(false).c_str(), libint2::libint_version_string(true).c_str(), libint2::libint_commit().c_str());
+printf("Version: Major=%d minor=%d patch=%d\n", std::get<0>(Mmp), std::get<1>(Mmp), std::get<2>(Mmp));
+printf("Citation: DOI=%s Ref=%s\n", libint2::libint_reference_doi().c_str(), libint2::libint_reference().c_str());
+printf("Citation: BibTex=%s\n", libint2::libint_bibtex().c_str());
+```
+```
+Version: Numeric=2.8.0 Sortable= Commit=
+Version: Major=2 minor=8 patch=0
+Citation: DOI= Ref=Libint: , Version  Edward F. Valeev, http://libint.valeyev.net/
+Citation: BibTex=@Misc{Libint2,
+  author = {E.~F.~Valeev},
+  title = {\textsc{Libint}: },
+  howpublished = {http://libint.valeyev.net/},
+  note = {version },
+  year = {}
+}
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,134 @@
+# Configuring Libint
+
+* Notes
+  * Codes "G", "L", or "C" for each option indicate whether it is consumed by the _g_enerator, the _l_ibrary, the library _c_onsumer, or a combination.
+    * If your final target is the export tarball, use options that include the letter "G".
+    * If you're building a library from an export TARBALL, use options that include the letter "L".
+    * For a continuous generator->export->library build, options supplied at the top level will be properly handed off to generator and library build.
+  * See [Update Guide](gnu-autotools-update-guide) for new names for old options.
+
+
+###  Which Integrals Classes, Which Derivative Levels (G)
+
+* `ENABLE_ONEBODY` — G — Compile with support for up to N-th derivatives of 1-body integrals. Use -1 for OFF. [Default=0]
+* `ENABLE_ERI` — G — Compile with support for up to N-th derivatives of 4-center electron repulsion integrals. Use -1 for OFF. [Default=0]
+* `ENABLE_ERI3` — G — Compile with support for up to N-th derivatives of 3-center electron repulsion integrals. Use -1 for OFF. [Default=-1]
+* `ENABLE_ERI2` — G — Compile with support for up to N-th derivatives of 2-center electron repulsion integrals. Use -1 for OFF. [Default=-1]
+* `ENABLE_G12` — G — Compile with support for N-th derivatives of MP2-F12 energies with Gaussian factors. Use -1 for OFF. [Default=-1]
+* `ENABLE_G12DKH` — G — Compile with support for N-th derivatives of DKH-MP2-F12 energies with Gaussian factors. Use -1 for OFF. [Default=-1]
+
+* `DISABLE_ONEBODY_PROPERTY_DERIVS` — G — Disable geometric derivatives of 1-body property integrals (all but overlap, kinetic, elecpot).
+   These derivatives are disabled by default to save compile time. Use OFF to enable.
+   Note that the libtool build won't enable this- if forcibly enabled, build_libint balks. [Default=ON]
+
+* `ENABLE_T1G12_SUPPORT` — G — Enable [Ti,G12] integrals when G12 integrals are enabled. Irrelevant when `ENABLE_G12=OFF`. Use OFF to disable. [Default=ON]
+
+
+###  Which Ordering Conventions (G)
+
+* `ERI3_PURE_SH` — G — Assume the 'unpaired' center of 3-center ERIs will be transformed to pure solid harmonics. [Default=OFF]
+* `ERI2_PURE_SH` — G — Assume the 2-center ERIs will be transformed to pure solid harmonics. [Default=OFF]
+
+
+###  How High Angular Momentum (G)
+
+* Notes
+  * example for "semicolon-separated string": `-DENABLE_ERI3=2 -DWITH_ERI3_MAX_AM="5;4;3"`. cmake configuration prints:
+
+    ```
+    -- Setting option ENABLE_ERI3: 2
+    -- Setting option WITH_ERI3_MAX_AM: 5;4;3
+    ```
+
+  * special considerations for high-AM library (L) builds:
+    * high MAX_AM generates a large number of source files. If unity builds are disabled, more than
+      ~20k files may require `ulimit -s 65535` for linking the library target on Linux to avert
+      "ld: Argument list too long".
+    * Ninja builds use beyond max threads and can run out of memory, resulting in errorless stops or
+      "CMake Error: Generator: execution of make failed". Throttle it to physical threads with
+      `export CMAKE_BUILD_PARALLEL_LEVEL=N`.
+
+* `WITH_MAX_AM` — G — Support Gaussians of angular momentum up to N. Can specify values for each derivative level as a semicolon-separated string. Specify values greater or equal to `WITH_<class>_MAX_AM`; often mirrors `WITH_ERI3_MAX_AM`. [Default=4]
+* `WITH_OPT_AM` — G — Optimize maximally for up to angular momentum N (N <= WITH_MAX_AM). Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `(WITH_MAX_AM/2)+1`]
+
+* `MULTIPOLE_MAX_ORDER` — G — Maximum order of spherical multipole integrals. There is no maximum. [Default=4]
+
+* `WITH_ONEBODY_MAX_AM` — G — Support 1-body ints for Gaussians of angular momentum up to N. Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_MAX_AM`]
+* `WITH_ONEBODY_OPT_AM` — G — Optimize 1-body ints maximally for up to angular momentum N (N <= max-am). Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_OPT_AM`]
+
+* `WITH_ERI_MAX_AM` — G — Support 4-center ERIs for Gaussians of angular momentum up to N. Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_MAX_AM`]
+* `WITH_ERI_OPT_AM` — G — Optimize 4-center ERIs maximally for up to angular momentum N (N <= max-am). Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_OPT_AM`]
+
+* `WITH_ERI3_MAX_AM` — G — Support 3-center ERIs for Gaussians of angular momentum up to N. Can specify values for each derivative level as a semicolon-separated string. This option controls only the single fitting center; the paired centers use WITH_MAX_AM. [Default=-1 -> `WITH_MAX_AM`]
+* `WITH_ERI3_OPT_AM` — G — Optimize 3-center ERIs maximally for up to angular momentum N (N <= max-am). Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_OPT_AM`]
+
+* `WITH_ERI2_MAX_AM` — G — Support 2-center ERIs for Gaussians of angular momentum up to N. Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_MAX_AM`]
+* `WITH_ERI2_OPT_AM` — G — Optimize 2-center ERIs maximally for up to angular momentum N (N <= max-am). Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_OPT_AM`]
+
+* `WITH_G12_MAX_AM` — G — Support integrals for G12 methods of angular momentum up to N. No specification with per-derivative list. [Default=-1 -> `WITH_MAX_AM`]
+* `WITH_G12_OPT_AM` — G — Optimize G12 integrals for up to angular momentum N (N <= max-am). No specification with per-derivative list. [Default=-1 `WITH_OPT_AM`]
+
+* `WITH_G12DKH_MAX_AM` — G — Support integrals for relativistic G12 methods of angular momentum up to N. No specification with per-derivative list. [Default=-1 -> `WITH_MAX_AM`]
+* `WITH_G12DKH_OPT_AM` — G — Optimize G12DKH integrals for up to angular momentum N (N <= max-am). No specification with per-derivative list. [Default=-1 `WITH_OPT_AM`]
+
+
+### Compilers and Flags (G L) (TARBALL)
+
+
+# GNU Autotools Update Guide
+
+* Notes
+  * Multiple option names can be from any long-lived branch but usually libtool+cmake --> final cmake+cmake.
+
+* `--enable-1body=N` --> `-D ENABLE_ONEBODY=N`
+* `--enable-eri=N` --> `-D ENABLE_ERI=N`
+* `--disable-eri` --> `-D ENABLE_ERI=-1`
+* `--enable-eri3=N` --> `-D ENABLE_ERI3=N`
+* `--enable-eri2=N` --> `-D ENABLE_ERI2=N`
+
+* `--enable-eri3-pure-sh` --> `-D ERI3_PURE_SH=ON`
+* `--enable-eri2-pure-sh` --> `-D ERI2_PURE_SH=ON`
+
+* `--with-max-am=N` --> `-D WITH_MAX_AM=N`
+* `--with-max-am=N0,N1,N2` --> `-D WITH_MAX_AM="N0;N1;N2"` (notice semicolons and quotes. This is standard CMake list syntax)
+* `--with-opt-am=N` --> `-D WITH_OPT_AM=N`
+* `--with-opt-am=N0,N1,N2` --> `-D WITH_OPT_AM="N0;N1;N2"`
+
+* `--with-multipole-max-order=N` --> `-D MULTIPOLE_MAX_ORDER=N`
+
+* `--with-1body-max-am=N` --> `-D WITH_ONEBODY_MAX_AM=N`
+* `--with-1body-max-am=N0,N1,N2` --> `-D WITH_ONEBODY_MAX_AM="N0;N1;N2"`
+* `--with-1body-opt-am=N` --> `-D WITH_ONEBODY_OPT_AM=N`
+* `--with-1body-opt-am=N0,N1,N2` --> `-D WITH_ONEBODY_OPT_AM="N0;N1;N2"`
+
+* `--with-eri-max-am=N` --> `-D WITH_ERI_MAX_AM=N`
+* `--with-eri-max-am=N0,N1,N2` --> `-D WITH_ERI_MAX_AM="N0;N1;N2"`
+* `--with-eri-opt-am=N` --> `-D WITH_ERI_OPT_AM=N`
+* `--with-eri-opt-am=N0,N1,N2` --> `-D WITH_ERI_OPT_AM="N0;N1;N2"`
+
+* `--with-eri3-max-am=N` --> `-D WITH_ERI3_MAX_AM=N`
+* `--with-eri3-max-am=N0,N1,N2` --> `-D WITH_ERI3_MAX_AM="N0;N1;N2"`
+* `--with-eri3-opt-am=N` --> `-D WITH_ERI3_OPT_AM=N`
+* `--with-eri3-opt-am=N0,N1,N2` --> `-D WITH_ERI3_OPT_AM="N0;N1;N2"`
+
+* `--with-eri2-max-am=N` --> `-D WITH_ERI2_MAX_AM=N`
+* `--with-eri2-max-am=N0,N1,N2` --> `-D WITH_ERI2_MAX_AM="N0;N1;N2"`
+* `--with-eri2-opt-am=N` --> `-D WITH_ERI2_OPT_AM=N`
+* `--with-eri2-opt-am=N0,N1,N2` --> `-D WITH_ERI2_OPT_AM="N0;N1;N2"`
+
+* `--enable-g12=N` --> `-D ENABLE_G12=N`
+* `--enable-g12dkh=N` --> `-D ENABLE_G12DKH`
+* `--disable-t1g12-support` --> `-D ENABLE_T1G12_SUPPORT=OFF`
+* `--with-g12-max-am=N` --> `-D WITH_G12_MAX_AM=N`
+* `--with-g12-opt-am=N` --> `-D WITH_G12_OPT_AM=N`
+* `--with-g12dkh-max-am=N` --> `-D WITH_G12DKH_MAX_AM=N`
+* `--with-g12dkh-opt-am=N` --> `-D WITH_G12DKH_OPT_AM=N`
+
+* `--disable-1body-property-derivs` --> `-D DISABLE_ONEBODY_PROPERTY_DERIVS=ON`
+
+
+
+
 ### Run-Time Compatibility
 
 Functions are provided to check the library configuration and solid harmonics orderings at runtime:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,8 +26,6 @@
 
 ###  Which Ordering Conventions (G)
 
-* `ERI3_PURE_SH` — G — Assume the 'unpaired' center of 3-center ERIs will be transformed to pure solid harmonics. [Default=OFF]
-* `ERI2_PURE_SH` — G — Assume the 2-center ERIs will be transformed to pure solid harmonics. [Default=OFF]
 
 
 ###  How High Angular Momentum (G)
@@ -61,9 +59,11 @@
 
 * `WITH_ERI3_MAX_AM` — G — Support 3-center ERIs for Gaussians of angular momentum up to N. Can specify values for each derivative level as a semicolon-separated string. This option controls only the single fitting center; the paired centers use WITH_MAX_AM. [Default=-1 -> `WITH_MAX_AM`]
 * `WITH_ERI3_OPT_AM` — G — Optimize 3-center ERIs maximally for up to angular momentum N (N <= max-am). Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_OPT_AM`]
+* `ERI3_PURE_SH` — G — Assume the 'unpaired' center of 3-center ERIs will be transformed to pure solid harmonics. [Default=OFF]
 
 * `WITH_ERI2_MAX_AM` — G — Support 2-center ERIs for Gaussians of angular momentum up to N. Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_MAX_AM`]
 * `WITH_ERI2_OPT_AM` — G — Optimize 2-center ERIs maximally for up to angular momentum N (N <= max-am). Can specify values for each derivative level as a semicolon-separated string. [Default=-1 -> `WITH_OPT_AM`]
+* `ERI2_PURE_SH` — G — Assume the 2-center ERIs will be transformed to pure solid harmonics. [Default=OFF]
 
 * `WITH_G12_MAX_AM` — G — Support integrals for G12 methods of angular momentum up to N. No specification with per-derivative list. [Default=-1 -> `WITH_MAX_AM`]
 * `WITH_G12_OPT_AM` — G — Optimize G12 integrals for up to angular momentum N (N <= max-am). No specification with per-derivative list. [Default=-1 `WITH_OPT_AM`]
@@ -223,7 +223,7 @@ Eventually, these will be CMake Components, too.
                      "h" (h=spdfghikl...; s,p not enumerated) and derivative order "D" (D=0,1,2,...).
                      For example, the presence of "eri_ffff_d1" means 4-center gradient ints are
                      available for L=3. That is, the library was configured with at least
-                     "--enable-eri=1 --with-eri-max-am=?,>=3".
+                     '-D ENABLE_ERI=1 -D WITH_ERI_MAX_AM="?;>=3"'.
    eri_hhL_dD      - library includes 2-body integrals with 3 centers and max angular momentum up to
    eri_hhl_dD        Cartesian "h" for the two paired centers and Cartesian "l" or solid harmonics "L"
                      for the unpaired/fitting center, (h/l=spdfghikl..., L=SPDFGHIKL...; l>=h
@@ -232,9 +232,9 @@ Eventually, these will be CMake Components, too.
                      solid harmonics are assumed for 3-center ints, "eri_hhl_dD" will *not be available*.
                      For example, the presence of "eri_ffG_d0" means 3-center energy ints are
                      available for L=3 (paired centers) and L=4 (fitting center). That is, the library
-                     was configured with at least "--enable-eri3=0 --with-max-am=3 --with-eri3-max-am=4".
+                     was configured with at least "-D ENABLE_ERI3=0 -D WITH_MAX_AM=3 -D WITH_ERI3_MAX_AM=4".
                      The presence of "eri_ffg_d0" means the library configuration did not additionally
-                     include "--enable-eri3-pure-sh[=yes]".
+                     include "-D ERI3_PURE_SH=ON".
    eri_HH_dD       - library includes 2-body integrals with 2 centers and max angular momentum up to
    eri_hh_dD         Cartesian "h" or solid harmonics "H", (h=spdfghikl..., H=SPDFGHIKL...; s,p,S,P not
                      enumerated) and derivative order "D" (D=0,1,2,...). The "eri_HH_dD" component is
@@ -242,8 +242,8 @@ Eventually, these will be CMake Components, too.
                      assumed for 2-center ints, "eri_hh_dD" will *not be available*.
                      For example, the presence of "eri_FF_d2" means 2-center Hessian ints are
                      available for L=3. That is, the library was configured with at least
-                     "--enable-eri2=2 --with-eri2-max-am=?,?,>=3". The presence of "eri_ff_d2" means the
-                     library configuration did not additionally include "--enable-eri2-pure-sh[=yes]".
+                     '-D ENABLE_ERI2=2 -D WITH_ERI2_MAX_AM="?;?;>=3"'. The presence of "eri_ff_d2" means the
+                     library configuration did not additionally include "-D ERI2_PURE_SH=ON".
    g12_hhhh_dD     - library includes F12 integrals with Gaussian factors and max angular momentum up to
                      "h" (h=spdfghikl...; s,p not enumerated) and derivative order "D" (D=0,1,2,...).
                      For example, the presence of "g12_iiii_d2" means g12 Hessian ints are available for L=6.

--- a/cmake/modules/.git_archival.txt
+++ b/cmake/modules/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=?[0-9.]*)$
+ref-names: $Format:%D$

--- a/cmake/modules/DynamicVersion.cmake
+++ b/cmake/modules/DynamicVersion.cmake
@@ -1,0 +1,375 @@
+# from https://github.com/LecrisUT/CMakeExtraUtils/commits/main on 11 Dec 2023 at 26450da
+# * 12 Dec 2023 added distance variable and field
+
+## Helper to get dynamic version
+# Format is made compatible with python's setuptools_scm (https://github.com/pypa/setuptools_scm#git-archives)
+
+function(dynamic_version)
+    # Configure project to use dynamic versioning
+    #
+    # Named arguments::
+    #   PROJECT_PREFIX (string): Prefix to be used for namespacing targets, typically ${PROJECT_NAME}
+    #   OUTPUT_VERSION (string) [PROJECT_VERSION]: Variable where to save the calculated version
+    #   OUTPUT_DESCRIBE (string) [GIT_DESCRIBE]: Variable where to save the pure git_describe
+    #   OUTPUT_COMMIT (string) [GIT_COMMIT]: Variable where to save the git commit
+    #   OUTPUT_DISTANCE (string) [GIT_DISTANCE]: Variable where to save the distance from git tag
+    #   PROJECT_SOURCE (path) [${CMAKE_CURRENT_SOURCE_DIR}]: Location of the project source.
+    #     (either extracted git archive or git clone)
+    #   GIT_ARCHIVAL_FILE (path) [${PROJECT_SOURCE}/.git_archival.txt]: Location of .git_archival.txt
+    #   FALLBACK_VERSION (string): Fallback version
+    #   FALLBACK_HASH (string): Fallback git hash. If not defined target GitHash will not be created if project is not a
+    #     git repo
+    #   TMP_FOLDER (path) [${CMAKE_CURRENT_BINARY_DIR}/tmp]: Temporary path to store temporary files
+    #   OUTPUT_FOLDER (path) [${CMAKE_CURRENT_BINARY_DIR}]: Path where to store generated files
+    #
+    # Options::
+    #   ALLOW_FAILS: Do not return with FATAL_ERROR. Developer is responsible for setting appropriate version if fails
+    #
+    # Targets::
+    #   ${PROJECT_PREFIX}Version: Target that recalculates the dynamic version each time
+    #   ${PROJECT_PREFIX}GitHash:
+    #
+    # Generated files::
+    #   (Note: files are regenerated only when they change)
+    #   ${OUTPUT_FOLDER}/.DynamicVersion.json: All computed data of DynamicVersion
+    #   ${OUTPUT_FOLDER}/.version: Extracted version
+    #   ${OUTPUT_FOLDER}/.git_describe: Computed git describe
+    #   ${OUTPUT_FOLDER}/.git_commit: Current commit
+
+    set(ARGS_Options "")
+    set(ARGS_OneValue "")
+    set(ARGS_MultiValue "")
+    list(APPEND ARGS_Options
+            ALLOW_FAILS
+            )
+    list(APPEND ARGS_OneValue
+            PROJECT_PREFIX
+            OUTPUT_VERSION
+            OUTPUT_DESCRIBE
+            OUTPUT_COMMIT
+            OUTPUT_DISTANCE
+            PROJECT_SOURCE
+            GIT_ARCHIVAL_FILE
+            FALLBACK_VERSION
+            FALLBACK_HASH
+            TMP_FOLDER
+            OUTPUT_FOLDER
+            )
+
+    cmake_parse_arguments(ARGS "${ARGS_Options}" "${ARGS_OneValue}" "${ARGS_MultiValue}" ${ARGN})
+
+    set(DynamicVersion_ARGS "")
+
+    # Set default values
+    if (NOT DEFINED ARGS_OUTPUT_VERSION)
+        set(ARGS_OUTPUT_VERSION PROJECT_VERSION)
+    endif ()
+    if (NOT DEFINED ARGS_OUTPUT_DESCRIBE)
+        set(ARGS_OUTPUT_DESCRIBE GIT_DESCRIBE)
+    endif ()
+    if (NOT DEFINED ARGS_OUTPUT_COMMIT)
+        set(ARGS_OUTPUT_COMMIT GIT_COMMIT)
+    endif ()
+    if (NOT DEFINED ARGS_OUTPUT_DISTANCE)
+        set(ARGS_OUTPUT_DISTANCE GIT_DISTANCE)
+    endif ()
+    if (NOT DEFINED ARGS_PROJECT_SOURCE)
+        set(ARGS_PROJECT_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
+    endif ()
+    if (NOT DEFINED ARGS_GIT_ARCHIVAL_FILE)
+        set(ARGS_GIT_ARCHIVAL_FILE ${ARGS_PROJECT_SOURCE}/.git_archival.txt)
+    endif ()
+    if (DEFINED ARGS_FALLBACK_VERSION OR ARGS_ALLOW_FAILS)
+        # If we have a fallback version or it is specified it is ok if this fails, don't make messages FATAL_ERROR
+        set(error_message_type AUTHOR_WARNING)
+    else ()
+        # Otherwise it should
+        set(error_message_type FATAL_ERROR)
+    endif ()
+    if (NOT ARGS_PROJECT_PREFIX)
+        message(AUTHOR_WARNING
+                "DynamicVersion: No PROJECT_PREFIX was given. Please provide one to avoid target name clashes")
+    elseif (NOT ARGS_PROJECT_PREFIX MATCHES ".*_$")
+        # Append an underscore _ to the prefix if not provided
+        message(AUTHOR_WARNING
+                "DynamicVersion: PROJECT_PREFIX did not contain an underscore, please add it for clarity")
+        set(ARGS_PROJECT_PREFIX ${ARGS_PROJECT_PREFIX}_)
+    endif ()
+    if (NOT DEFINED ARGS_TMP_FOLDER)
+        set(ARGS_TMP_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/tmp)
+    endif ()
+    if (NOT DEFINED ARGS_OUTPUT_FOLDER)
+        set(ARGS_OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR})
+    endif ()
+    if (ARGS_OUTPUT_FOLDER EQUAL ARGS_TMP_FOLDER)
+        message(FATAL_ERROR
+                "DynamicVersion misconfigured: Cannot have both OUTPUT_FOLDER and TMP_FOLDER point to the same path")
+    endif ()
+
+    list(APPEND DynamicVersion_ARGS
+            PROJECT_SOURCE ${ARGS_PROJECT_SOURCE}
+            GIT_ARCHIVAL_FILE ${ARGS_GIT_ARCHIVAL_FILE}
+            TMP_FOLDER ${ARGS_TMP_FOLDER}
+            )
+    if (DEFINED ARGS_FALLBACK_VERSION)
+        list(APPEND DynamicVersion_ARGS
+                FALLBACK_VERSION ${ARGS_FALLBACK_VERSION})
+    endif ()
+    if (DEFINED ARGS_FALLBACK_HASH)
+        list(APPEND DynamicVersion_ARGS
+                FALLBACK_HASH ${ARGS_FALLBACK_HASH})
+    endif ()
+    if (ARGS_ALLOW_FAILS)
+        list(APPEND DynamicVersion_ARGS ALLOW_FAILS)
+    endif ()
+    # Normalize DynamicVersion_ARGS to be passed as string
+    list(JOIN DynamicVersion_ARGS "\\;" DynamicVersion_ARGS)
+
+    # Execute get_dynamic_version once to know the current configuration
+    execute_process(COMMAND ${CMAKE_COMMAND}
+            -DDynamicVersion_RUN:BOOL=True
+            # Note: DynamicVersion_ARGS cannot be escaped with ""
+            -DDynamicVersion_ARGS:STRING=${DynamicVersion_ARGS}
+            -P ${CMAKE_CURRENT_FUNCTION_LIST_FILE}
+            COMMAND_ERROR_IS_FATAL ANY)
+
+    # Copy all configured files
+    foreach (file IN ITEMS .DynamicVersion.json .version .git_describe .git_commit)
+        if (EXISTS ${file})
+            file(COPY_FILE ${ARGS_TMP_FOLDER}/${file} ${ARGS_OUTPUT_FOLDER}/${file})
+        endif ()
+    endforeach ()
+
+    # Check configuration state
+    file(READ ${ARGS_TMP_FOLDER}/.DynamicVersion.json data)
+    string(JSON failed GET ${data} failed)
+    string(JSON ${ARGS_OUTPUT_VERSION} ERROR_VARIABLE _ GET ${data} version)
+    string(JSON ${ARGS_OUTPUT_DESCRIBE} ERROR_VARIABLE _ GET ${data} describe)
+    string(JSON ${ARGS_OUTPUT_COMMIT} ERROR_VARIABLE _ GET ${data} commit)
+    string(JSON ${ARGS_OUTPUT_DISTANCE} ERROR_VARIABLE _ GET ${data} distance)
+
+    # Configure targets
+    if (failed)
+        # If configuration failed, create dummy targets
+        add_custom_target(${ARGS_PROJECT_PREFIX}Version
+                COMMAND ${CMAKE_COMMAND} -E true)
+        add_custom_target(${ARGS_PROJECT_PREFIX}GitHash
+                COMMAND ${CMAKE_COMMAND} -E true)
+    else ()
+        # Otherwise create the targets outputting to the appropriate files
+        add_custom_target(${ARGS_PROJECT_PREFIX}DynamicVersion ALL
+                BYPRODUCTS ${ARGS_TMP_FOLDER}/.DynamicVersion.json ${ARGS_TMP_FOLDER}/.git_describe ${ARGS_TMP_FOLDER}/.version
+                COMMAND ${CMAKE_COMMAND}
+                -DDynamicVersion_RUN:BOOL=True
+                # Note: For some reason DynamicVersion_ARGS needs "" here, but it doesn't in execute_process
+                -DDynamicVersion_ARGS:STRING="${DynamicVersion_ARGS}"
+                -P ${CMAKE_CURRENT_FUNCTION_LIST_FILE}
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ARGS_TMP_FOLDER}/.DynamicVersion.json ${ARGS_OUTPUT_FOLDER}/.DynamicVersion.json
+                )
+        add_custom_target(${ARGS_PROJECT_PREFIX}Version ALL
+                DEPENDS ${ARGS_PROJECT_PREFIX}DynamicVersion
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ARGS_TMP_FOLDER}/.git_describe ${ARGS_OUTPUT_FOLDER}/.git_describe
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ARGS_TMP_FOLDER}/.version ${ARGS_OUTPUT_FOLDER}/.version
+                )
+        add_custom_target(${ARGS_PROJECT_PREFIX}GitHash
+                DEPENDS ${ARGS_PROJECT_PREFIX}DynamicVersion
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ARGS_TMP_FOLDER}/.git_commit ${ARGS_OUTPUT_FOLDER}/.git_commit
+                )
+    endif ()
+
+    # This ensures that the project is reconfigured (at least at second run) whenever the version changes
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND
+            PROPERTY CMAKE_CONFIGURE_DEPENDS ${ARGS_OUTPUT_FOLDER}/.version)
+
+    message(VERBOSE
+            "DynamicVersion: Calculated version = ${${ARGS_OUTPUT_VERSION}}")
+
+    if (CMAKE_VERSION VERSION_LESS 3.25)
+        # TODO: Remove when cmake 3.25 is commonly distributed
+        set(${ARGS_OUTPUT_DESCRIBE} ${${ARGS_OUTPUT_DESCRIBE}} PARENT_SCOPE)
+        set(${ARGS_OUTPUT_VERSION} ${${ARGS_OUTPUT_VERSION}} PARENT_SCOPE)
+        set(${ARGS_OUTPUT_COMMIT} ${${ARGS_OUTPUT_COMMIT}} PARENT_SCOPE)
+        set(${ARGS_OUTPUT_DISTANCE} ${${ARGS_OUTPUT_DISTANCE}} PARENT_SCOPE)
+    endif ()
+    return(PROPAGATE
+            ${ARGS_OUTPUT_DESCRIBE}
+            ${ARGS_OUTPUT_VERSION}
+            ${ARGS_OUTPUT_COMMIT}
+            ${ARGS_OUTPUT_DISTANCE}
+            )
+endfunction()
+
+function(get_dynamic_version)
+    # Compute the dynamic version
+    #
+    # Named arguments::
+    #   PROJECT_SOURCE (path): Location of the project source.
+    #     (either extracted git archive or git clone)
+    #   GIT_ARCHIVAL_FILE (path): Location of .git_archival.txt
+    #   FALLBACK_VERSION (string): Fallback version
+    #   FALLBACK_HASH (string): Fallback git hash. If not defined target GitHash will not be created if project is not a
+    #     git repo
+    #   TMP_FOLDER (path): Temporary path to store temporary files
+
+    set(ARGS_Options "")
+    set(ARGS_OneValue "")
+    set(ARGS_MultiValue "")
+    list(APPEND ARGS_OneValue
+            PROJECT_SOURCE
+            GIT_ARCHIVAL_FILE
+            FALLBACK_VERSION
+            FALLBACK_HASH
+            TMP_FOLDER
+            )
+    list(APPEND ARGS_Options
+            ALLOW_FAILS
+            )
+
+    cmake_parse_arguments(ARGS "${ARGS_Options}" "${ARGS_OneValue}" "${ARGS_MultiValue}" ${ARGN})
+
+    if (DEFINED ARGS_FALLBACK_VERSION OR ARGS_ALLOW_FAILS)
+        # If we have a fallback version or it is specified it is ok if this fails, don't make messages FATAL_ERROR
+        set(error_message_type AUTHOR_WARNING)
+    else ()
+        # Otherwise it should fail
+        set(error_message_type FATAL_ERROR)
+    endif ()
+
+    set(data "{}")
+    # Default set
+    string(JSON data SET ${data} failed true)
+    if (ARGS_ALLOW_FAILS)
+        string(JSON data SET ${data} allow-fails true)
+    else ()
+        string(JSON data SET ${data} allow-fails false)
+    endif ()
+
+    # Set fallback values
+    if (DEFINED ARGS_FALLBACK_VERSION)
+        string(JSON data SET
+                ${data} version ${ARGS_FALLBACK_VERSION})
+        file(WRITE ${ARGS_TMP_FOLDER}/.DynamicVersion.json ${data})
+        file(WRITE ${ARGS_TMP_FOLDER}/.version ${ARGS_FALLBACK_VERSION})
+    endif ()
+    if (DEFINED ARGS_FALLBACK_HASH)
+        string(JSON data SET
+                ${data} commit ${ARGS_FALLBACK_HASH})
+        file(WRITE ${ARGS_TMP_FOLDER}/.DynamicVersion.json ${data})
+        file(WRITE ${ARGS_TMP_FOLDER}/.git_commit ${ARGS_FALLBACK_HASH})
+    endif ()
+
+
+    if (NOT EXISTS ${ARGS_GIT_ARCHIVAL_FILE})
+        # If git_archival.txt is missing, project is ill-formed
+        message(${error_message_type}
+                "DynamicVersion: Missing file .git_archival.txt\n"
+                "  .git_archival.txt: ${ARGS_GIT_ARCHIVAL_FILE}")
+        return()
+    endif ()
+
+    # Get version dynamically from git_archival.txt
+    file(STRINGS ${ARGS_GIT_ARCHIVAL_FILE} describe-name
+            REGEX "^describe-name:.*")
+    if (NOT describe-name)
+        # If git_archival.txt does not contain the field "describe-name:", it is ill-formed
+        message(${error_message_type}
+                "DynamicVersion: Missing string \"describe-name\" in .git_archival.txt\n"
+                "  .git_archival.txt: ${ARGS_GIT_ARCHIVAL_FILE}")
+        return()
+    endif ()
+
+    # Try to get the version tag of the form `vX.Y.Z` or `X.Y.Z` (with arbitrary suffix)
+    if (describe-name MATCHES "^describe-name:[ ]?([v]?([0-9\\.]+).*)")
+        # First matched group is the full `git describe` of the latest tag
+        # Second matched group is only the version, i.e. `X.Y.Z`
+        string(JSON data SET
+                ${data} describe \"${CMAKE_MATCH_1}\")
+        file(WRITE ${ARGS_TMP_FOLDER}/.git_describe ${CMAKE_MATCH_1})
+        string(JSON data SET
+                ${data} version \"${CMAKE_MATCH_2}\")
+        file(WRITE ${ARGS_TMP_FOLDER}/.version ${CMAKE_MATCH_2})
+        # Get commit hash
+        file(STRINGS ${ARGS_GIT_ARCHIVAL_FILE} node
+                REGEX "^node:[ ]?(.*)")
+        string(JSON data SET
+                ${data} commit \"${CMAKE_MATCH_1}\")
+        file(WRITE ${ARGS_TMP_FOLDER}/.git_commit ${CMAKE_MATCH_1})
+        message(DEBUG "DynamicVersion: Found appropriate tag in .git_archival.txt file")
+    else ()
+        # If not it has to be computed from the git archive
+        find_package(Git REQUIRED)
+        # Test if project is a git repository
+        execute_process(COMMAND ${GIT_EXECUTABLE} status
+                WORKING_DIRECTORY ${ARGS_PROJECT_SOURCE}
+                RESULT_VARIABLE git_status_result
+                OUTPUT_QUIET)
+        if (NOT git_status_result EQUAL 0)
+            message(${error_message_type}
+                    "DynamicVersion: Project source is neither a git repository nor a git archive:\n"
+                    "  Source: ${ARGS_PROJECT_SOURCE}")
+            return()
+        endif ()
+        # Get most recent commit hash
+        execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+                WORKING_DIRECTORY ${ARGS_PROJECT_SOURCE}
+                OUTPUT_VARIABLE git-hash
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                COMMAND_ERROR_IS_FATAL ANY)
+        # Get version and describe-name
+        execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --match=?[0-9.]*
+                WORKING_DIRECTORY ${ARGS_PROJECT_SOURCE}
+                OUTPUT_VARIABLE describe-name
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                COMMAND_ERROR_IS_FATAL ANY)
+        # Match any part containing digits and periods (strips out rc and so on)
+        if (NOT describe-name MATCHES "^([v]?([0-9\\.]+).*)")
+            message(${error_message_type}
+                    "DynamicVersion: Version tag is ill-formatted\n"
+                    "  Describe-name: ${describe-name}")
+            return()
+        endif ()
+        string(JSON data SET
+                ${data} describe \"${CMAKE_MATCH_1}\")
+        file(WRITE ${ARGS_TMP_FOLDER}/.git_describe ${CMAKE_MATCH_1})
+        string(JSON data SET
+                ${data} version \"${CMAKE_MATCH_2}\")
+        file(WRITE ${ARGS_TMP_FOLDER}/.version ${CMAKE_MATCH_2})
+        # Get full describe with distance
+        execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --long --match=?[0-9.]*
+                WORKING_DIRECTORY ${ARGS_PROJECT_SOURCE}
+                OUTPUT_VARIABLE describe-name-long
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                COMMAND_ERROR_IS_FATAL ANY)
+        # Match version (as above) and distance
+        if (NOT describe-name-long MATCHES "^([v]?([0-9\\.]+)-([0-9]+)-.*)")
+            message(${error_message_type}
+                    "DynamicVersion: Version tag is ill-formatted\n"
+                    "  Describe-name-long: ${describe-name-long}")
+            return()
+        endif ()
+        string(JSON data SET
+                ${data} distance \"${CMAKE_MATCH_3}\")
+        file(WRITE ${ARGS_TMP_FOLDER}/.git_distance ${CMAKE_MATCH_3})
+        string(JSON data SET
+                ${data} commit \"${git-hash}\")
+        file(WRITE ${ARGS_TMP_FOLDER}/.git_commit ${git-hash})
+        message(DEBUG "DynamicVersion: Found appropriate tag from git")
+    endif ()
+
+    # Mark success and output results
+    string(JSON data SET ${data} failed false)
+    message(DEBUG
+            "DynamicVersion: Computed data:\n"
+            "  data = ${data}")
+    file(WRITE ${ARGS_TMP_FOLDER}/.DynamicVersion.json ${data})
+endfunction()
+
+# Logic to run get_dynamic_version() by running this script
+if (DynamicVersion_RUN)
+    if (NOT DEFINED DynamicVersion_ARGS)
+        message(FATAL_ERROR
+                "DynamicVersion: DynamicVersion_ARGS not defined")
+    endif ()
+    get_dynamic_version(${DynamicVersion_ARGS})
+endif ()
+

--- a/cmake/modules/int_am.cmake
+++ b/cmake/modules/int_am.cmake
@@ -1,4 +1,456 @@
 # handle the defaulting and setting of the following variables
 # * ENABLE_[ONEBODY|ERI2|ERI3|ERI|G12|G12DKH]
 # * [LIBINT|ONEBODY|ERI2|ERI3|ERI|G12|G12DKH]_[MAX|OPT]_AM[|_LIST]
+# * MULTIPOLE_MAX_ORDER
+# * LIBINT_ONEBODY_DERIV
+# * LIBINT_SUPPORTS_ONEBODY
+# * SUPPORT_T1G12
 
+# "_candidate" variables are not needed for config.h but are used to figure out
+#   the AM limits at the CMake level so that libint2-config.cmake components may
+#   be defined and consuming codes can state their requirements. For example,
+#   `find_package(Libint2 REQUIRED COMPONENTS eri_hhhh_d1)` requires the detected
+#   library to include gradient integrals of at least AM=5.
+#   See INSTALL.md for details.
+
+set(LIBINT_HARD_MAX_AM 12)
+# amstr = "SPDFGHIKLMNOPQRTUVWXYZ"
+set(_am2 "d")
+set(_am3 "f")
+set(_am4 "g")
+set(_am5 "h")
+set(_am6 "i")
+set(_am7 "k")
+set(_am8 "l")
+set(_am9 "m")
+set(_am10 "n")
+set(_am11 "o")
+set(_am12 "p")
+set(_AM2 "D")
+set(_AM3 "F")
+set(_AM4 "G")
+set(_AM5 "H")
+set(_AM6 "I")
+set(_AM7 "K")
+set(_AM8 "L")
+set(_AM9 "M")
+set(_AM10 "N")
+set(_AM11 "O")
+set(_AM12 "P")
+
+macro(numerical_max_of_list ansvar liste)
+    set(_max "-100")
+    foreach(_i ${liste})
+        if (${_i} GREATER _max)
+            set(_max "${_i}")
+        endif()
+    endforeach()
+    set(${ansvar} "${_max}")
+endmacro()
+
+
+message(STATUS "Processing integrals classes ...")
+
+# <<<  overall derivatives level  >>>
+
+set(_glob_classes_derivs ${ENABLE_ONEBODY};${ENABLE_ERI};${ENABLE_ERI3};${ENABLE_ERI2};${ENABLE_G12};${ENABLE_G12DKH})
+numerical_max_of_list(_max_deriv "${_glob_classes_derivs}")
+message(STATUS "Preparing highest derivative level ${_max_deriv}")
+
+# <<<  overall max_am defaults  >>>
+
+list(LENGTH WITH_MAX_AM _ntokens_maxam)
+if (_ntokens_maxam GREATER 1)
+    math(EXPR _ntokens_xptd_max_deriv "${_max_deriv} + 1")
+    if (NOT _ntokens_xptd_max_deriv EQUAL _ntokens_maxam)
+        message(FATAL_ERROR "Invalid value for WITH_MAX_AM (${WITH_MAX_AM}). Highest ENABLE_ derivative (${_max_deriv}) requires list length ${_ntokens_xptd_max_deriv}, not ${_ntokens_maxam}.")
+    endif()
+
+    numerical_max_of_list(_max_am "${WITH_MAX_AM}")
+    list(JOIN WITH_MAX_AM "," _sam)
+    set(LIBINT_MAX_AM_LIST ${_sam})
+    # when LIST populated, only overall LIBINT (not specific ints classes) sets both MAX_AM & MAX_AM_LIST
+    set(LIBINT_MAX_AM ${_max_am})
+    set(_max_LIBINT_MAX_AM ${LIBINT_MAX_AM})
+else()
+    set(LIBINT_MAX_AM_LIST "")
+    set(LIBINT_MAX_AM ${WITH_MAX_AM})
+endif()
+
+foreach(_d RANGE 0 ${_max_deriv})
+    if (${_d} LESS _ntokens_maxam)
+        list(GET WITH_MAX_AM ${_d} _candidate0_d${_d})
+    else()
+        set(_candidate0_d${_d} "-1")
+    endif()
+    # _candidate0_dD=int_am defined up to highest ENABLE_cls deriv D from best info from WITH_MAX_AM
+    message(VERBOSE "setting _candidate0_d${_d}=${_candidate0_d${_d}}")
+endforeach()
+
+if (LIBINT_MAX_AM GREATER_EQUAL ${LIBINT_HARD_MAX_AM})
+    message(WARNING "LIBINT_MAX_AM=${LIBINT_MAX_AM} is greater than ${LIBINT_HARD_MAX_AM}. Are you sure you know what you are doing?")
+elseif (LIBINT_MAX_AM LESS_EQUAL 0)
+    message(FATAL_ERROR "Invalid value for LIBINT_MAX_AM (${LIBINT_MAX_AM}).")
+endif()
+
+message(STATUS "Preparing generic LIBINT_MAX_AM_LIST ${LIBINT_MAX_AM_LIST} and LIBINT_MAX_AM ${LIBINT_MAX_AM} for integrals class defaults.")
+
+# <<<  overall opt_am defaults  >>>
+
+list(LENGTH WITH_OPT_AM _ntokens_optam)
+if (NOT WITH_OPT_AM EQUAL -1)
+    if (NOT _ntokens_optam EQUAL _ntokens_maxam)
+        # discard two cases: scalar opt and list max -and- list opt and scalar max
+        message(FATAL_ERROR "Invalid format for WITH_OPT_AM (${WITH_OPT_AM}). Use the same format and length like `N` or `N0;N1;N2` as WITH_MAX_AM (${WITH_MAX_AM}).")
+    endif()
+endif()
+if (_ntokens_optam GREATER 1)
+    # list opt and list max: use list opt validating aginst max
+    set(_processed_OPT_AM_LIST )
+    math(EXPR _range_limit "${_ntokens_maxam} - 1")
+    foreach(_d RANGE ${_range_limit})
+        list(GET WITH_MAX_AM ${_d} _max_am)
+        list(GET WITH_OPT_AM ${_d} _opt_am)
+        if (_opt_am LESS_EQUAL _max_am)
+            list(APPEND _processed_OPT_AM_LIST ${_opt_am})
+        else()
+            list(APPEND _processed_OPT_AM_LIST ${_max_am})
+        endif()
+    endforeach()
+
+    list(JOIN _processed_OPT_AM_LIST "," LIBINT_OPT_AM_LIST)
+    numerical_max_of_list(LIBINT_OPT_AM "${_processed_OPT_AM_LIST}")
+else()
+    if(WITH_OPT_AM EQUAL -1)
+        # first branch is a nice default pattern but not exactly what configure.ac prescribes, so bypassing it
+        # if (_ntokens_maxam GREATER 1)
+        if (FALSE)
+            # no opt and list max: default list opt from max
+            set(_processed_OPT_AM_LIST )
+            math(EXPR _range_limit "${_ntokens_maxam} - 1")
+            foreach(_d RANGE ${_range_limit})
+                list(GET WITH_MAX_AM ${_d} _max_am)
+                math(EXPR _opt_am "${_max_am}/2 + 1")
+                list(APPEND _processed_OPT_AM_LIST ${_opt_am})
+            endforeach()
+
+            list(JOIN _processed_OPT_AM_LIST "," LIBINT_OPT_AM_LIST)
+            numerical_max_of_list(LIBINT_OPT_AM "${_processed_OPT_AM_LIST}")
+        else()
+            # no opt and scalar max: default scalar opt from max
+            set(LIBINT_OPT_AM_LIST "")
+            math(EXPR LIBINT_OPT_AM "${LIBINT_MAX_AM}/2 + 1")
+        endif()
+    else()
+        # scalar opt and scalar max: use scalar opt validating aginst max
+        set(LIBINT_OPT_AM_LIST "")
+        set(LIBINT_OPT_AM ${WITH_OPT_AM})
+
+        if (LIBINT_OPT_AM GREATER LIBINT_MAX_AM)
+            set(LIBINT_OPT_AM ${LIBINT_MAX_AM})
+        endif()
+    endif()
+endif()
+
+message(STATUS "Preparing generic LIBINT_OPT_AM_LIST ${LIBINT_OPT_AM_LIST} and LIBINT_OPT_AM ${LIBINT_OPT_AM} for integrals class defaults.")
+
+# <<<  Macro  >>>
+
+macro(process_integrals_class class)
+
+    list(LENGTH ENABLE_${class} _ntokens)
+    if (NOT _ntokens EQUAL 1)
+        message(FATAL_ERROR "Invalid value for ENABLE_${class} (${ENABLE_${class}}). Use scalar of maximum derivative level, not list.")
+    endif()
+
+    if (ENABLE_${class} GREATER_EQUAL 0)
+        set(INCLUDE_${class} ${ENABLE_${class}})
+
+        foreach(_d RANGE 0 ${_max_deriv})
+            if (${_d} LESS_EQUAL ${INCLUDE_${class}})
+                set(_candidate0_${class}_d${_d} ${_candidate0_d${_d}})
+                message(VERBOSE "setting _candidate0_${class}_d${_d}=${_candidate0_${class}_d${_d}}")
+            endif()
+        endforeach()
+
+        set(LIBINT_SUPPORTS_${class} yes)
+        set(LIBINT_${class}_DERIV ${INCLUDE_${class}})
+        message(STATUS "Enabling integrals class ${class} to derivative ${INCLUDE_${class}}")
+    else()
+        set(INCLUDE_${class} "-1")
+        set(${class}_MAX_AM "")
+        set(${class}_MAX_AM_LIST "")
+        message(STATUS "Disabling integrals class ${class}")
+    endif()
+
+    if (ENABLE_${class} GREATER_EQUAL 0)
+        list(LENGTH WITH_${class}_MAX_AM _ntokens)
+        if (_ntokens GREATER 1)
+            math(EXPR _ntokens_xptd_max_deriv "${INCLUDE_${class}} + 1")
+            if (NOT _ntokens_xptd_max_deriv EQUAL _ntokens)
+                message(FATAL_ERROR "Invalid value for WITH_${class}_MAX_AM (${WITH_${class}_MAX_AM}). ENABLE_${class} derivative (${INCLUDE_${class}}) requires list length ${_ntokens_xptd_max_deriv}, not ${_ntokens}.")
+            endif()
+
+            foreach(_d RANGE ${INCLUDE_${class}})
+                list(GET WITH_${class}_MAX_AM ${_d} _candidate_${class}_d${_d})
+                message(VERBOSE "setting _candidate_${class}_d${_d}=${_candidate_${class}_d${_d}}")
+
+                if (_candidate_${class}_d${_d} LESS_EQUAL 0)
+                    message(FATAL_ERROR "Invalid value for WITH_${class}_MAX_AM derivative element ${_d} (${_candidate_${class}_d${_d}} <= 0).")
+                endif()
+            endforeach()
+
+            list(JOIN WITH_${class}_MAX_AM "," ${class}_MAX_AM_LIST)
+            set(${class}_MAX_AM "")
+        else()
+            set(${class}_MAX_AM_LIST "")
+            if (WITH_${class}_MAX_AM EQUAL -1)
+                foreach(_d RANGE ${INCLUDE_${class}})
+                    if (${_candidate0_${class}_d${_d}} EQUAL -1)
+                        set(_candidate_${class}_d${_d} ${_candidate0_${class}_d0})
+                    else()
+                        set(_candidate_${class}_d${_d} ${_candidate0_${class}_d${_d}})
+                    endif()
+                    message(VERBOSE "setting _candidate_${class}_d${_d}=${_candidate_${class}_d${_d}}")
+                endforeach()
+
+                set(${class}_MAX_AM "")
+                # note: could set class_MAX_AM/LIST from default (in configure.ac, looks like at least scalar var set)
+                #       but philosophy is to set user-only intent and leave further defaulting to compiled code. wrong?
+            else()
+                set(${class}_MAX_AM ${WITH_${class}_MAX_AM})
+
+                foreach(_d RANGE ${INCLUDE_${class}})
+                    set(_candidate_${class}_d${_d} ${${class}_MAX_AM})
+                    message(VERBOSE "setting _candidate_${class}_d${_d}=${_candidate_${class}_d${_d}}")
+                endforeach()
+
+                if (${class}_MAX_AM GREATER_EQUAL ${LIBINT_HARD_MAX_AM})
+                    message(WARNING "Value for ${class}_MAX_AM too high (${${class}_MAX_AM} >= ${LIBINT_HARD_MAX_AM}). Are you sure you know what you are doing?")
+                elseif (${class}_MAX_AM LESS_EQUAL 0)
+                    message(FATAL_ERROR "Invalid value for ${class}_MAX_AM (${${class}_MAX_AM} <= 0).")
+                endif()
+            endif()
+        endif()
+        if (LIBINT_MAX_AM_LIST)
+            set(_msg ${LIBINT_MAX_AM_LIST})
+        else()
+            set(_msg ${LIBINT_MAX_AM})
+        endif()
+        message(STATUS "Enabling integrals class ${class} to max AM ${${class}_MAX_AM}${${class}_MAX_AM_LIST} (else ${_msg})")
+
+        list(LENGTH WITH_${class}_OPT_AM _ntokens)
+        if (_ntokens GREATER 1)
+            if (NOT _ntokens_xptd_max_deriv EQUAL _ntokens)
+                message(FATAL_ERROR "Invalid value for WITH_${class}_OPT_AM (${WITH_${class}_OPT_AM}). ENABLE_${class} derivative (${INCLUDE_${class}}) requires list length ${_ntokens_xptd_max_deriv}, not ${_ntokens}.")
+            endif()
+
+            list(JOIN WITH_${class}_OPT_AM "," ${class}_OPT_AM_LIST)
+            set(${class}_OPT_AM "")
+        else()
+            set(${class}_OPT_AM_LIST "")
+            if (WITH_${class}_OPT_AM EQUAL -1)
+                set(${class}_OPT_AM "")
+            else()
+                set(${class}_OPT_AM ${WITH_${class}_OPT_AM})
+            endif()
+        endif()
+        if (LIBINT_OPT_AM_LIST)
+            set(_msg ${LIBINT_OPT_AM_LIST})
+        else()
+            set(_msg ${LIBINT_OPT_AM})
+        endif()
+        message(STATUS "Enabling integrals class ${class} to opt AM ${${class}_OPT_AM}${${class}_OPT_AM_LIST} (else ${_msg})")
+    endif()
+endmacro()
+
+
+macro(process_integrals_class_alt class)
+
+    list(LENGTH ENABLE_${class} _ntokens)
+    if (NOT _ntokens EQUAL 1)
+        message(FATAL_ERROR "Invalid value for ENABLE_${class} (${ENABLE_${class}}). Use scalar of maximum derivative level, not list.")
+    endif()
+
+    if (ENABLE_${class} GREATER_EQUAL 0)
+        set(INCLUDE_${class} ${ENABLE_${class}})
+
+        foreach(_d RANGE 0 ${_max_deriv})
+            if (${_d} LESS_EQUAL ${INCLUDE_${class}})
+                # no per-d defaults. use energy
+                set(_candidate0_${class}_d${_d} ${_candidate0_d0})
+                message(VERBOSE "setting _candidate0_${class}_d${_d}=${_candidate0_${class}_d${_d}}")
+            endif()
+        endforeach()
+
+        set(LIBINT_SUPPORTS_${class} yes)
+        set(LIBINT_${class}_DERIV ${INCLUDE_${class}})
+        message(STATUS "Enabling integrals class ${class} to derivative ${INCLUDE_${class}}")
+    else()
+        set(INCLUDE_${class} "-1")
+        set(${class}_MAX_AM "")
+        message(STATUS "Disabling integrals class ${class}")
+    endif()
+
+    if (ENABLE_${class} GREATER_EQUAL 0)
+        list(LENGTH WITH_${class}_MAX_AM _ntokens)
+        if (_ntokens GREATER 1)
+            message(FATAL_ERROR "Invalid value for WITH_${class}_MAX_AM (${WITH_${class}_MAX_AM}). ENABLE_${class} derivative supports only scalar, not list length ${_ntokens}.")
+
+        else()
+            if (WITH_${class}_MAX_AM EQUAL -1)
+                foreach(_d RANGE ${INCLUDE_${class}})
+                    set(_candidate_${class}_d${_d} ${_candidate0_${class}_d0})
+                    message(VERBOSE "setting _candidate_${class}_d${_d}=${_candidate_${class}_d0}")
+                endforeach()
+
+                set(_${class}_MAX_AM_pre "")
+                set(${class}_MAX_AM ${_candidate0_${class}_d0})
+                # note: unlike usual classes, C++ code seems to want class_MAX_AM set explicitly to config.h
+            else()
+                set(_${class}_MAX_AM_pre ${WITH_${class}_MAX_AM})
+                set(${class}_MAX_AM ${WITH_${class}_MAX_AM})
+
+                foreach(_d RANGE ${INCLUDE_${class}})
+                    set(_candidate_${class}_d${_d} ${${class}_MAX_AM})
+                    message(VERBOSE "setting _candidate_${class}_d${_d}=${_candidate_${class}_d${_d}}")
+                endforeach()
+
+                if (${class}_MAX_AM GREATER_EQUAL ${LIBINT_HARD_MAX_AM})
+                    message(WARNING "Value for ${class}_MAX_AM too high (${${class}_MAX_AM} >= ${LIBINT_HARD_MAX_AM}). Are you sure you know what you are doing?")
+                elseif (${class}_MAX_AM LESS_EQUAL 0)
+                    message(FATAL_ERROR "Invalid value for ${class}_MAX_AM (${${class}_MAX_AM} <= 0).")
+                endif()
+            endif()
+        endif()
+        message(STATUS "Enabling integrals class ${class} to max AM ${_${class}_MAX_AM_pre} (else ${LIBINT_MAX_AM})")
+
+        list(LENGTH WITH_${class}_OPT_AM _ntokens)
+        if (_ntokens GREATER 1)
+            message(FATAL_ERROR "Invalid value for WITH_${class}_OPT_AM (${WITH_${class}_OPT_AM}). ENABLE_${class} derivative supports only scalar, not list length ${_ntokens}.")
+
+        else()
+            if (WITH_${class}_OPT_AM EQUAL -1)
+                set(_${class}_OPT_AM_pre "")
+                set(${class}_OPT_AM ${LIBINT_OPT_AM})
+                # note: unlike usual classes, C++ code seems to want class_MAX_AM set explicitly
+            else()
+                set(_${class}_OPT_AM_pre ${WITH_${class}_OPT_AM})
+                set(${class}_OPT_AM ${WITH_${class}_OPT_AM})
+            endif()
+        endif()
+        message(STATUS "Enabling integrals class ${class} to opt AM ${_${class}_OPT_AM_pre} (else ${LIBINT_OPT_AM})")
+    endif()
+endmacro()
+
+
+process_integrals_class(ONEBODY)
+process_integrals_class(ERI)
+process_integrals_class(ERI3)
+process_integrals_class(ERI2)
+# unlike above, these classes (1) don't do AM_LIST and (2) require value in config.h if enabled
+process_integrals_class_alt(G12)
+process_integrals_class_alt(G12DKH)
+
+if (ENABLE_G12 GREATER_EQUAL 0)
+    set(SUPPORT_T1G12 ${ENABLE_T1G12_SUPPORT})
+else()
+    set(SUPPORT_T1G12 OFF)
+endif()
+
+add_feature_info(
+  "general integral"
+  "ON"
+  "config.h: LIBINT_MAX_AM=${LIBINT_MAX_AM} LIBINT_MAX_AM_LIST=${LIBINT_MAX_AM_LIST} LIBINT_OPT_AM=${LIBINT_OPT_AM} LIBINT_OPT_AM_LIST=${LIBINT_OPT_AM_LIST}"
+  )
+
+# form list of active class + deriv + max_am strings to use in libint2-config.cmake
+# * this generates components in same order as export/cmake/configuration-gen.py
+set(Libint2_ERI_COMPONENTS "")
+set(_amlist "")
+set(_eri3_impure_sh "")
+set(_eri2_impure_sh "")
+add_feature_info(
+  "integral class MULTIPOLE derivative 0"
+  "MULTIPOLE_MAX_ORDER"
+  "max_am ${MULTIPOLE_MAX_ORDER}"
+  )
+foreach(_l RANGE 2 ${MULTIPOLE_MAX_ORDER})
+    # RANGE with count-down works but docs say behavior is undefined, so we count-up and reverse
+    # RANGE starting at 2 avoids enumerating s, p
+    set(_lbl "multipole_${_am${_l}}${_am${_l}}_d0")
+    list(APPEND _amlist "${_lbl}")
+endforeach()
+list(REVERSE _amlist)
+list(APPEND Libint2_ERI_COMPONENTS "${_amlist}")
+message(VERBOSE "setting components ${_amlist}")
+
+foreach(_cls ONEBODY;ERI;ERI3;ERI2;G12;G12DKH)
+    if((_cls STREQUAL G12) OR (_cls STREQUAL G12DKH))
+        add_feature_info(
+          "integral class ${_cls}"
+          "INCLUDE_${_cls} GREATER -1"
+          "config.h: INCLUDE_${_cls}=${INCLUDE_${_cls}} ${_cls}_MAX_AM=${${_cls}_MAX_AM} ${_cls}_OPT_AM=${${_cls}_OPT_AM}"
+          )
+    else()
+        add_feature_info(
+          "integral class ${_cls}"
+          "INCLUDE_${_cls} GREATER -1"
+          "config.h: INCLUDE_${_cls}=${INCLUDE_${_cls}} ${_cls}_MAX_AM=${${_cls}_MAX_AM} ${_cls}_MAX_AM_LIST=${${_cls}_MAX_AM_LIST} ${_cls}_OPT_AM=${${_cls}_OPT_AM} ${_cls}_OPT_AM_LIST=${${_cls}_OPT_AM_LIST}"
+          )
+    endif()
+    if(_cls STREQUAL "G12DKH")
+        # add G12DKH below when it's granted components
+        continue()
+    endif()
+    if (INCLUDE_${_cls} GREATER -1)
+        foreach (_d RANGE 0 ${INCLUDE_${_cls}})
+            add_feature_info(
+              "integral class ${_cls} derivative ${_d}"
+              "INCLUDE_${_cls} GREATER -1"
+              "max_am ${_candidate_${_cls}_d${_d}}"
+              )
+            set(_amlist "")
+            set(_pureamlist "")
+            foreach(_l RANGE 2 ${_candidate_${_cls}_d${_d}})  # LIBINT_cls_MAX_AM[_LIST]
+                if (_cls STREQUAL "ERI")
+                    list(APPEND _amlist             "eri_${_am${_l}}${_am${_l}}${_am${_l}}${_am${_l}}_d${_d}")
+                elseif (_cls STREQUAL "ERI2")
+                    list(APPEND _amlist             "eri_${_AM${_l}}${_AM${_l}}_d${_d}")
+                    list(APPEND _pureamlist         "eri_${_am${_l}}${_am${_l}}_d${_d}")
+                elseif (_cls STREQUAL "ONEBODY")
+                    list(APPEND _amlist         "onebody_${_am${_l}}${_am${_l}}_d${_d}")
+                elseif (_cls STREQUAL "G12")
+                    list(APPEND _amlist             "g12_${_am${_l}}${_am${_l}}${_am${_l}}${_am${_l}}_d${_d}")
+                endif()
+            endforeach()
+            if (_cls STREQUAL "ERI3")
+                foreach(_lpr RANGE 2 ${_candidate0_d${_d}})  # LIBINT_MAX_AM[_LIST]
+                    foreach(_lfit RANGE 2 ${_candidate_${_cls}_d${_d}})  # LIBINT_ERI3_MAX_AM[_LIST]
+                        if (_lfit GREATER_EQUAL _lpr)
+                            list(APPEND _amlist     "eri_${_am${_lpr}}${_am${_lpr}}${_AM${_lfit}}_d${_d}")
+                            list(APPEND _pureamlist "eri_${_am${_lpr}}${_am${_lpr}}${_am${_lfit}}_d${_d}")
+                        endif()
+                    endforeach()
+                endforeach()
+            endif()
+            list(REVERSE _amlist)
+            list(APPEND Libint2_ERI_COMPONENTS "${_amlist}")
+            message(VERBOSE "setting component ${_amlist}")
+            list(REVERSE _pureamlist)
+            if (_cls STREQUAL "ERI2")
+                list(APPEND _eri2_impure_sh "${_pureamlist}")
+            elseif (_cls STREQUAL "ERI3")
+                list(APPEND _eri3_impure_sh "${_pureamlist}")
+            endif()
+        endforeach()
+        if ((_cls STREQUAL "ERI3") AND NOT ERI3_PURE_SH)
+            list(APPEND Libint2_ERI_COMPONENTS "${_eri3_impure_sh}")
+            message(VERBOSE "setting component ${_eri3_impure_sh}")
+        elseif ((_cls STREQUAL "ERI2") AND NOT ERI2_PURE_SH)
+            list(APPEND Libint2_ERI_COMPONENTS "${_eri2_impure_sh}")
+            message(VERBOSE "setting component ${_eri2_impure_sh}")
+        endif()
+    endif()
+endforeach()
+message(STATUS "Library will satisfy ERI AM components: ${Libint2_ERI_COMPONENTS}")

--- a/cmake/modules/int_am.cmake
+++ b/cmake/modules/int_am.cmake
@@ -1,0 +1,4 @@
+# handle the defaulting and setting of the following variables
+# * ENABLE_[ONEBODY|ERI2|ERI3|ERI|G12|G12DKH]
+# * [LIBINT|ONEBODY|ERI2|ERI3|ERI|G12|G12DKH]_[MAX|OPT]_AM[|_LIST]
+

--- a/cmake/modules/int_versions.cmake
+++ b/cmake/modules/int_versions.cmake
@@ -1,0 +1,66 @@
+# top-level CMakeLists.txt has defined:
+# * PROJECT_VERSION_{MAJOR|MINOR|PATCH} through `project(... VERSION)`
+# * LIBINT_BUILDID
+# * LIBINT_SOVERSION
+# * LibintRepository_{VERSION|DESCRIBE|COMMIT|DISTANCE} through `dynamic_version()`
+
+# note that 3rd version integer is PATCH in CMake and MICRO in Libint
+# see also int_computed.cmake.in for transmitting these values to the library's CMake
+# note that with the dynamic/git scheme, it's important for repo to be up-to-date with tags
+
+
+# <<<  Sortable Version  >>>
+
+message(DEBUG "LibintRepository_VERSION  ${LibintRepository_VERSION}")
+message(DEBUG "LibintRepository_COMMIT   ${LibintRepository_COMMIT}")
+message(DEBUG "LibintRepository_DISTANCE ${LibintRepository_DISTANCE}")
+message(DEBUG "LibintRepository_DESCRIBE ${LibintRepository_DESCRIBE}")
+
+if (LibintRepository_DISTANCE STREQUAL "0")
+    set(LIBINT_SORTABLE_VERSION "${LibintRepository_VERSION}")
+else()
+    set(LIBINT_SORTABLE_VERSION "${LibintRepository_VERSION}.post${LibintRepository_DISTANCE}")
+endif()
+
+string(SUBSTRING ${LibintRepository_COMMIT} 0 7 LIBINT_GIT_COMMIT)
+message(DEBUG "LIBINT_GIT_COMMIT         ${LIBINT_GIT_COMMIT}")
+
+string(TIMESTAMP LIBINT_VERSION_YEAR "%Y")
+message(DEBUG "LIBINT_VERSION_YEAR       ${LIBINT_VERSION_YEAR}")
+
+
+# <<<  Build Version  >>>
+
+set(LIBINT_MAJOR_VERSION ${PROJECT_VERSION_MAJOR})
+set(LIBINT_MINOR_VERSION ${PROJECT_VERSION_MINOR})
+set(LIBINT_MICRO_VERSION ${PROJECT_VERSION_PATCH})
+
+set(LIBINT_VERSION ${LIBINT_MAJOR_VERSION}.${LIBINT_MINOR_VERSION}.${LIBINT_MICRO_VERSION})
+
+
+# <<<  Dev Version  >>>
+
+if (LIBINT_BUILDID)
+  set(LIBINT_EXT_VERSION ${LIBINT_VERSION}-${LIBINT_BUILDID})
+else()
+  set(LIBINT_EXT_VERSION ${LIBINT_VERSION})
+endif()
+
+message(STATUS "Version: Full ${LIBINT_EXT_VERSION} Numeric ${LIBINT_VERSION} Sortable ${LIBINT_SORTABLE_VERSION}")
+
+if (NOT(LibintRepository_VERSION STREQUAL LIBINT_VERSION))
+    message(AUTHOR_WARNING
+        "Version processing has gone wrong: ${LibintRepository_VERSION STREQUAL} != ${LIBINT_VERSION}")
+endif()
+
+
+# <<<  ABI Version  >>>
+
+string(REPLACE ":" ";" LIBINT_SOVERSION_LIST ${LIBINT_SOVERSION})
+
+list(GET LIBINT_SOVERSION_LIST 0 LIBINT_CURRENT_SOVERSION)
+list(GET LIBINT_SOVERSION_LIST 1 LIBINT_REVISION_SOVERSION)
+list(GET LIBINT_SOVERSION_LIST 2 LIBINT_AGE_SOVERSION)
+
+math(EXPR LIBINT_MAJOR_SOVERSION "${LIBINT_CURRENT_SOVERSION} - ${LIBINT_AGE_SOVERSION}")
+message(STATUS "SO Version: Full ${LIBINT_SOVERSION} Major ${LIBINT_MAJOR_SOVERSION}")

--- a/cmake/modules/int_versions.cmake
+++ b/cmake/modules/int_versions.cmake
@@ -1,7 +1,9 @@
 # top-level CMakeLists.txt has defined:
 # * PROJECT_VERSION_{MAJOR|MINOR|PATCH} through `project(... VERSION)`
+# * Libint2Compiler_DESCRIPTION through `project(... DESCRIPTION)`
 # * LIBINT_BUILDID
 # * LIBINT_SOVERSION
+# * LIBINT_DOI
 # * LibintRepository_{VERSION|DESCRIBE|COMMIT|DISTANCE} through `dynamic_version()`
 
 # note that 3rd version integer is PATCH in CMake and MICRO in Libint
@@ -25,9 +27,13 @@ endif()
 string(SUBSTRING ${LibintRepository_COMMIT} 0 7 LIBINT_GIT_COMMIT)
 message(DEBUG "LIBINT_GIT_COMMIT         ${LIBINT_GIT_COMMIT}")
 
+# Below goes into BibTeX citation. Currently year of export. For year of tag, parse:
+# `git show -s --no-notes --date=short --pretty='%cd' v2.7.2` responds: 2022-06-20
 string(TIMESTAMP LIBINT_VERSION_YEAR "%Y")
 message(DEBUG "LIBINT_VERSION_YEAR       ${LIBINT_VERSION_YEAR}")
 
+set(LIBINT_DESCRIPTION "${Libint2Compiler_DESCRIPTION}")
+message(DEBUG "LIBINT_DESCRIPTION        ${LIBINT_DESCRIPTION}")
 
 # <<<  Build Version  >>>
 

--- a/cmake/modules/options.cmake
+++ b/cmake/modules/options.cmake
@@ -1,0 +1,187 @@
+### based on https://github.com/psi4/psi4/blob/master/cmake/psi4OptionsTools.cmake
+
+#Macro for printing an option in a consistent manner
+#
+#Syntax: print_option(<option to print> <was specified>)
+#
+macro(print_option variable default)
+if(NOT DEFINED ${variable} OR "${${variable}}" STREQUAL "")
+    message(STATUS "Setting (unspecified) option ${variable}: ${default}")
+else()
+    message(STATUS "Setting option ${variable}: ${${variable}}")
+endif()
+endmacro()
+
+# Wraps an option with default ON/OFF. Adds nice messaging to option()
+#
+#Syntax: option_with_print(<option name> <description> <default value>)
+#
+macro(option_with_print variable msge default)
+   print_option(${variable} ${default})
+   option(${variable} ${msge} ${default})
+endmacro(option_with_print)
+
+# Call to cast T/F, ON/OFF, 0/1, etc. to 0/1, usually for ifdef purposes.
+macro(booleanize01 variable)
+    if (DEFINED ${variable} OR DEFINED CACHE{${variable}})
+        if(${variable})
+            set(_new_value 1)
+        else()
+            set(_new_value 0)
+        endif()
+        if (DEFINED CACHE{${variable}})
+            get_property(_cache_type CACHE ${variable} PROPERTY TYPE)
+            get_property(_cache_docstring CACHE ${variable} PROPERTY HELPSTRING)
+            set(${variable} ${_new_value} CACHE ${_cache_type} "${_cache_docstring}" FORCE)
+        else()
+            set(${variable} ${_new_value})
+        endif()
+    endif()
+endmacro(booleanize01)
+
+#Wraps an option with a default other than ON/OFF and prints it
+#NOTE: Can't combine with above b/c CMake handles ON/OFF options specially
+#NOTE2: CMAKE_BUILD_TYPE (and other CMake variables) are always defined so need
+#       to further check for if they are the NULL string.  This is also why we
+#       need the force
+#NOTE3: If option X does not start with LIBINT_ will look for LIBINT_X first; if
+#       not given will look for X and assign LIBINT_X to its value
+#
+#Syntax: option_with_default(<option name> <description> <default value>)
+#
+macro(option_with_default variable msge default)
+    # TODO: need to namespace all Libint-specific cmake variables
+    # disabled for now, pending discussion with @loriab
+    if (TRUE OR ${variable} MATCHES "^LIBINT_")
+        print_option(${variable} ${default})
+        if(NOT DEFINED ${variable} OR "${${variable}}" STREQUAL "")
+            set(${variable} "${default}" CACHE STRING "${msge}" FORCE)
+        endif()
+    else ()
+        set(_libint_var LIBINT_${variable})
+        print_option(${_libint_var} ${default})
+        if(NOT DEFINED ${_libint_var} OR "${${_libint_var}}" STREQUAL "")
+            if(DEFINED ${variable} AND (NOT "${${variable}}" STREQUAL ""))
+                set(${_libint_var} "${variable}" CACHE STRING "${msge}" FORCE)
+            else()
+                set(${_libint_var} "${default}" CACHE STRING "${msge}" FORCE)
+            endif()
+        endif()
+    endif()
+endmacro(option_with_default)
+
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+if(CMAKE_Fortran_COMPILER)
+    include(CheckFortranCompilerFlag)  # CMake >= 3.3, so local copy in cmake/
+endif()
+
+#The guts of the next two functions, use the wrappers please
+#
+#Syntax: add_C_or_CXX_flags(<True for C, False for CXX>)
+#
+# Note: resist adding -Werror to the check_X_compiler_flag calls,
+#   as (i) the flag for Intel is actually -diag-error warn, (ii)
+#   Intel ifort doesn't define -Werror, and (iii) passing it
+#   changes REQUIRED_DEFINITIONS.
+macro(add_C_or_CXX_flags is_C)
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+   set(CMAKE_REQUIRED_QUIET ON)
+   set(flags_to_try "${ARGN}")
+   foreach(flag_i IN LISTS flags_to_try ITEMS -brillig)
+      if(${flag_i} STREQUAL "-brillig")
+         message(WARNING "Option unfulfilled as none of ${flags_to_try} valid")
+         break()
+      endif()
+      unset(test_option CACHE)
+      if(${is_C} EQUAL 0)
+          CHECK_C_COMPILER_FLAG("${flag_i}" test_option)
+          set(description_to_print CMAKE_C_FLAGS)
+      elseif(${is_C} EQUAL 1)
+          CHECK_CXX_COMPILER_FLAG("${flag_i}" test_option)
+          set(description_to_print CMAKE_CXX_FLAGS)
+      elseif(${is_C} EQUAL 2)
+          CHECK_Fortran_COMPILER_FLAG("${flag_i}" test_option)
+          set(description_to_print CMAKE_Fortran_FLAGS)
+      endif()
+      set(msg_base "Performing Test ${description_to_print} [${flag_i}] -")
+      if(${test_option})
+        set(${description_to_print} "${${description_to_print}} ${flag_i}")
+        if(NOT CMAKE_REQUIRED_QUIET_SAVE)
+           message(STATUS  "${msg_base} Success, Appending")
+        endif()
+        break()
+      else()
+        if(NOT CMAKE_REQUIRED_QUIET_SAVE)
+           message(STATUS "${msg_base} Failed")
+        endif()
+      endif()
+   endforeach()
+   set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})  
+endmacro()
+
+
+
+#Checks if C flags are valid, if so adds them to CMAKE_C_FLAGS
+#Input should be a list of flags to try.  If two flags are to be tried together
+#enclose them in quotes, e.g. "-L/path/to/dir -lmylib" is tried as a single
+#flag, whereas "-L/path/to/dir" "-lmylib" is tried as two separate flags.
+#The first list item to succeed is added to CMAKE_C_FLAGS, then try loop
+#breaks. Warning issued if no flags in list succeed.
+#
+#
+#Syntax: add_C_flags(<flags to add>)
+#
+macro(add_C_flags)
+   add_C_or_CXX_flags(0 ${ARGN})
+endmacro()
+
+#Checks if CXX flags are valid, if so adds them to CMAKE_CXX_FLAGS
+#See add_C_flags for more info on syntax
+#
+#Syntax: add_CXX_flags(<flags to add>)
+#
+macro(add_CXX_flags)
+    add_C_or_CXX_flags(1 ${ARGN})
+endmacro()
+
+#Checks if Fortran flags are valid, if so adds them to CMAKE_Fortran_FLAGS
+#See add_C_flags for more info on syntax
+#
+#Syntax: add_Fortran_flags(<flags to add>)
+#
+macro(add_Fortran_flags)
+    add_C_or_CXX_flags(2 ${ARGN})
+endmacro()
+
+#Macro for adding flags common to both C and CXX, if the compiler supports them
+#
+#Syntax: add_flags(<flags to add>)
+#
+macro(add_flags FLAGS)
+    get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+    list(FIND languages "C" _index_c)
+    list(FIND languages "CXX" _index_cxx)
+    list(FIND languages "Fortran" _index_fortran)
+    if (${_index_c} GREATER -1)
+        add_C_flags(${FLAGS})
+    endif()
+    if (${_index_cxx} GREATER -1)
+        add_CXX_flags(${FLAGS})
+    endif()
+    if (${_index_fortran} GREATER -1)
+        add_Fortran_flags(${FLAGS})
+    endif()
+endmacro()
+
+#Defines an option that if enabled turns on some compiler flags
+#
+#Syntax: option_with_flags(<option> <description> <default value> <flags>)
+#
+macro(option_with_flags option msg default)
+    print_option(${option} ${default})
+    option(${option} ${msg} ${default})
+    if(${${option}})
+       add_flags("${ARGN}")
+    endif()
+endmacro()

--- a/include/libint2/config.h.cmake.in
+++ b/include/libint2/config.h.cmake.in
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (C) 2004-2023 Edward F. Valeev
+ *
+ *  This file is part of Libint.
+ *
+ *  Libint is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Libint is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Libint.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* This file is automatically processed by CMake.
+   It MUST NOT be changed manually after configuration, otherwise
+   the library will likely fail to compile or produce erroneous results
+ */
+
+#ifndef _libint2_include_libint2config_h_
+#define _libint2_include_libint2config_h_
+
+/* Support 1-body derivatives up to this order */
+#define INCLUDE_ONEBODY @INCLUDE_ONEBODY@
+#if @INCLUDE_ONEBODY@ == -1
+#undef INCLUDE_ONEBODY
+#endif
+
+/* Disable support for 1-body property derivatives */
+#cmakedefine DISABLE_ONEBODY_PROPERTY_DERIVS @DISABLE_ONEBODY_PROPERTY_DERIVS@
+
+/* Support ERI derivatives up to this order */
+#define INCLUDE_ERI @INCLUDE_ERI@
+#if @INCLUDE_ERI@ == -1
+#undef INCLUDE_ERI
+#endif
+
+/* Support 3-center ERI derivatives up to this order */
+#define INCLUDE_ERI3 @INCLUDE_ERI3@
+#if @INCLUDE_ERI3@ == -1
+#undef INCLUDE_ERI3
+#endif
+
+/* Support 2-center ERI derivatives up to this order */
+#define INCLUDE_ERI2 @INCLUDE_ERI2@
+#if @INCLUDE_ERI2@ == -1
+#undef INCLUDE_ERI2
+#endif
+
+/* Support G12 derivatives up to this order */
+#define INCLUDE_G12 @INCLUDE_G12@
+#if @INCLUDE_G12@ == -1
+#undef INCLUDE_G12
+#endif
+
+/* Support G12DKH derivatives up to this order */
+#define INCLUDE_G12DKH @INCLUDE_G12DKH@
+#if @INCLUDE_G12DKH@ == -1
+#undef INCLUDE_G12DKH
+#endif
+
+/* Max AM for one-body ints */
+#cmakedefine ONEBODY_MAX_AM @ONEBODY_MAX_AM@
+
+/* Max optimized AM for one-body ints */
+#cmakedefine ONEBODY_OPT_AM @ONEBODY_OPT_AM@
+
+/* Max order of spherical multipole ints */
+#cmakedefine MULTIPOLE_MAX_ORDER @MULTIPOLE_MAX_ORDER@
+
+/* Max AM for ERI (same for all derivatives; if not defined see ERI_MAX_AM_LIST) */
+#cmakedefine ERI_MAX_AM @ERI_MAX_AM@
+
+/* Max AM for ERI and its derivatives */
+#cmakedefine ERI_MAX_AM_LIST "@ERI_MAX_AM_LIST@"
+
+/* Max optimized AM for ERI (same for all derivatives; if not defined see ERI_OPT_AM_LIST) */
+#cmakedefine ERI_OPT_AM @ERI_OPT_AM@
+
+/* Max optimized AM for ERI and its derivatives */
+#cmakedefine ERI_OPT_AM_LIST "@ERI_OPT_AM_LIST@"
+
+/* Max AM for 3-center ERI (same for all derivatives; if not defined see ERI3_MAX_AM_LIST) */
+#cmakedefine ERI3_MAX_AM @ERI3_MAX_AM@
+
+/* Max AM for 3-center ERI and its derivatives */
+#cmakedefine ERI3_MAX_AM_LIST "@ERI3_MAX_AM_LIST@"
+
+/* Max optimized AM for 3-center ERI (same for all derivatives; if not defined see ERI3_OPT_AM_LIST) */
+#cmakedefine ERI3_OPT_AM @ERI3_OPT_AM@
+
+/* Max optimized AM for 3-center ERI and its derivatives */
+#cmakedefine ERI3_OPT_AM_LIST "@ERI3_OPT_AM_LIST@"
+
+/* If 1, assume will transform the "unpaired" center (e.g. a in (a|cd)) to solid harmonics */
+#cmakedefine ERI3_PURE_SH @ERI3_PURE_SH@
+
+/* Max AM for 2-center ERI (same for all derivatives; if not defined see ERI2_MAX_AM_LIST) */
+#cmakedefine ERI2_MAX_AM @ERI2_MAX_AM@
+
+/* Max AM for 2-center ERI and its derivatives */
+#cmakedefine ERI2_MAX_AM_LIST "@ERI2_MAX_AM_LIST@"
+
+/* Max optimized AM for 2-center ERI (same for all derivatives; if not defined see ERI2_OPT_AM_LIST) */
+#cmakedefine ERI2_OPT_AM @ERI2_OPT_AM@
+
+/* Max optimized AM for 2-center ERI and its derivatives */
+#cmakedefine ERI2_OPT_AM_LIST "@ERI2_OPT_AM_LIST@"
+
+/* If 1, assume will transform to solid harmonics */
+#cmakedefine ERI2_PURE_SH @ERI2_PURE_SH@
+
+/* Max AM for G12 method integrals */
+#cmakedefine G12_MAX_AM @G12_MAX_AM@
+
+/* Max optimized AM for G12 method integrals */
+#cmakedefine G12_OPT_AM @G12_OPT_AM@
+
+/* Support [Ti,G12] ? */
+#cmakedefine01 SUPPORT_T1G12
+
+/* Max AM for G12DKH method integrals */
+#cmakedefine G12DKH_MAX_AM @G12DKH_MAX_AM@
+
+/* Max optimized AM for G12DKH method integrals */
+#cmakedefine G12DKH_OPT_AM @G12DKH_OPT_AM@
+
+/* compiler type detection */
+#define LIBINT_COMPILER_ID_GNU 0
+#define LIBINT_COMPILER_ID_Clang 1
+#define LIBINT_COMPILER_ID_AppleClang 2
+#define LIBINT_COMPILER_ID_XLClang 3
+#define LIBINT_COMPILER_ID_Intel 4
+#if defined(__INTEL_COMPILER_BUILD_DATE)  /* macros like __ICC and even __INTEL_COMPILER can be affected by command options like -no-icc */
+# define LIBINT_COMPILER_ID LIBINT_COMPILER_ID_Intel
+# define LIBINT_COMPILER_IS_ICC 1
+#endif
+#if defined(__clang__) && !defined(LIBINT_COMPILER_IS_ICC)
+# define LIBINT_COMPILER_IS_CLANG 1
+# if defined(__apple_build_version__)
+#  define LIBINT_COMPILER_ID LIBINT_COMPILER_ID_AppleClang
+# elif defined(__ibmxl__)
+#  define LIBINT_COMPILER_ID LIBINT_COMPILER_ID_XLClang
+# else
+#  define LIBINT_COMPILER_ID LIBINT_COMPILER_ID_Clang
+# endif
+#endif
+#if defined(__GNUG__) && !defined(LIBINT_COMPILER_IS_ICC) && !defined(LIBINT_COMPILER_IS_CLANG)
+# define LIBINT_COMPILER_ID LIBINT_COMPILER_ID_GNU
+# define LIBINT_COMPILER_IS_GCC 1
+#endif
+
+/* ----------- pragma helpers ---------------*/
+#define LIBINT_PRAGMA(x) _Pragma(#x)
+/* same as LIBINT_PRAGMA(x), but expands x */
+#define LIBINT_XPRAGMA(x) LIBINT_PRAGMA(x)
+/* "concats" a and b with a space in between */
+#define LIBINT_CONCAT(a,b) a b
+#if defined(LIBINT_COMPILER_IS_CLANG)
+#define LIBINT_PRAGMA_CLANG(x) LIBINT_XPRAGMA( LIBINT_CONCAT(clang,x) )
+#else
+#define LIBINT_PRAGMA_CLANG(x)
+#endif
+#if defined(LIBINT_COMPILER_IS_GCC)
+#define LIBINT_PRAGMA_GCC(x) LIBINT_XPRAGMA( LIBINT_CONCAT(GCC,x) )
+#else
+#define LIBINT_PRAGMA_GCC(x)
+#endif
+
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(deprecated)
+#define LIBINT_DEPRECATED(msg) [[deprecated(msg)]]
+#endif
+#endif
+#ifndef LIBINT_DEPRECATED
+#define LIBINT_DEPRECATED(msg) LIBINT_XPRAGMA( LIBINT_CONCAT(message, msg) )
+#endif
+
+#endif /* header guard */

--- a/include/libint2/config.h.cmake.in
+++ b/include/libint2/config.h.cmake.in
@@ -26,6 +26,18 @@
 #ifndef _libint2_include_libint2config_h_
 #define _libint2_include_libint2config_h_
 
+/* Max AM (same for all derivatives; if not defined see LIBINT_MAX_AM_LIST) */
+#cmakedefine LIBINT_MAX_AM @LIBINT_MAX_AM@
+
+/* Max AM for integrals and their derivatives */
+#cmakedefine LIBINT_MAX_AM_LIST "@LIBINT_MAX_AM_LIST@"
+
+/* Max optimized AM (same for all derivatives; if not defined see LIBINT_OPT_AM_LIST) */
+#cmakedefine LIBINT_OPT_AM @LIBINT_OPT_AM@
+
+/* Max optimized AM for integrals and their derivatives */
+#cmakedefine LIBINT_OPT_AM_LIST "@LIBINT_OPT_AM_LIST@"
+
 /* Support 1-body derivatives up to this order */
 #define INCLUDE_ONEBODY @INCLUDE_ONEBODY@
 #if @INCLUDE_ONEBODY@ == -1
@@ -65,11 +77,17 @@
 #undef INCLUDE_G12DKH
 #endif
 
-/* Max AM for one-body ints */
+/* Max AM for one-body ints (same for all derivatives; if not defined see ONEBODY_MAX_AM_LIST) */
 #cmakedefine ONEBODY_MAX_AM @ONEBODY_MAX_AM@
 
-/* Max optimized AM for one-body ints */
+/* Max AM for one-body and its derivatives */
+#cmakedefine ONEBODY_MAX_AM_LIST "@ONEBODY_MAX_AM_LIST@"
+
+/* Max optimized AM for one-body ints (same for all derivatives; if not defined see ONEBODY_OPT_AM_LIST) */
 #cmakedefine ONEBODY_OPT_AM @ONEBODY_OPT_AM@
+
+/* Max optimized AM for one-body and its derivatives */
+#cmakedefine ONEBODY_OPT_AM_LIST "@ONEBODY_OPT_AM_LIST@"
 
 /* Max order of spherical multipole ints */
 #cmakedefine MULTIPOLE_MAX_ORDER @MULTIPOLE_MAX_ORDER@

--- a/include/libint2/config.h.in
+++ b/include/libint2/config.h.in
@@ -80,11 +80,17 @@
 /* Support G12DKH derivatives up to this order */
 #undef INCLUDE_G12DKH
 
-/* Max AM for one-body ints */
+/* Max AM for one-body ints (same for all derivatives; if not defined see ONEBODY_MAX_AM_LIST) */
 #undef ONEBODY_MAX_AM
 
-/* Max optimized AM for one-body ints */
+/* Max AM for one-body and its derivatives */
+#undef ONEBODY_MAX_AM_LIST
+
+/* Max optimized AM for one-body ints (same for all derivatives; if not defined see ONEBODY_OPT_AM_LIST) */
 #undef ONEBODY_OPT_AM
+
+/* Max optimized AM for one-body and its derivatives */
+#undef ONEBODY_OPT_AM_LIST
 
 /* Max order of spherical multipole ints */
 #undef MULTIPOLE_MAX_ORDER

--- a/include/libint2/util/configuration.h
+++ b/include/libint2/util/configuration.h
@@ -21,6 +21,8 @@
 #ifndef _libint2_include_libint2_util_configuration_h_
 #define _libint2_include_libint2_util_configuration_h_
 
+#include <stdbool.h>
+
 /* Runtime accessor for the library configuration:
    integral derivatives, AM, orderings, etc.
    @return the semicolon-separated strings from CMake components */
@@ -31,9 +33,9 @@ void libint_version(int *, int *, int *);
 
 /* Get the version of Libint as a string
     @return the version string. At release, strictly "M.m.p" (no alpha/rc/etc.).
-    Beyond release (ext=True), returns "M.m.p.postD" where D is distance from
-   release. Beyond release (ext=False), returns most recent release, "M.m.p". */
-const char *libint_version_string(bool ext = true);
+    Beyond release (arg=true), returns "M.m.p.postD" where D is distance from
+   release. Beyond release (arg=false), returns most recent release, "M.m.p". */
+const char *libint_version_string(bool);
 
 /* Get the git commit at which library was generated
     @return the commit as a 7-char abbreviated string */
@@ -96,8 +98,8 @@ inline std::tuple<int, int, int> libint_version() {
 /// @param[in] whether to return the simple-sortable last release or a
 /// per-commit version
 /// @return the version string. At release, strictly "M.m.p" (no alpha/rc/etc.).
-/// Beyond release (ext=True), returns "M.m.p.postD" where D is distance from
-/// release. Beyond release (ext=False), returns most recent release, "M.m.p".
+/// Beyond release (ext=true), returns "M.m.p.postD" where D is distance from
+/// release. Beyond release (ext=false), returns most recent release, "M.m.p".
 inline std::string libint_version_string(bool ext = true) {
   std::string version = ::libint_version_string(ext);
   return version;

--- a/include/libint2/util/configuration.h
+++ b/include/libint2/util/configuration.h
@@ -24,12 +24,38 @@
 /* Runtime accessor for the library configuration:
    integral derivatives, AM, orderings, etc.
    @return the semicolon-separated strings from CMake components */
-const char* configuration_accessor();
+const char *configuration_accessor();
+
+/* Get the major, minor, and micro version of Libint */
+void libint_version(int *, int *, int *);
+
+/* Get the version of Libint as a string
+    @return the version string. At release, strictly "M.m.p" (no alpha/rc/etc.).
+    Beyond release (ext=True), returns "M.m.p.postD" where D is distance from
+   release. Beyond release (ext=False), returns most recent release, "M.m.p". */
+const char *libint_version_string(bool ext = true);
+
+/* Get the git commit at which library was generated
+    @return the commit as a 7-char abbreviated string */
+const char *libint_commit(void);
+
+/* Literature citation
+    @return the citation string including description and version */
+const char *libint_reference(void);
+
+/* Literature citation DOI
+   @return the string of DOI for latest tag */
+const char *libint_reference_doi(void);
+
+/* BibTeX for citing Libint
+   @return the string for literature citation */
+const char *libint_bibtex(void);
 
 #ifdef __cplusplus
 #include <algorithm>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace libint2 {
@@ -57,6 +83,54 @@ inline bool supports(std::string component) {
       (std::find(seglist.begin(), seglist.end(), component) != seglist.end());
   return tf;
 }
+
+/// Get the major, minor, and micro version of Libint */
+/// @return the components of the last release
+inline std::tuple<int, int, int> libint_version() {
+  int vmajor, vminor, vmicro;
+  ::libint_version(&vmajor, &vminor, &vmicro);
+  return std::make_tuple(vmajor, vminor, vmicro);
+}
+
+/// Get the version of Libint as a string
+/// @param[in] whether to return the simple-sortable last release or a
+/// per-commit version
+/// @return the version string. At release, strictly "M.m.p" (no alpha/rc/etc.).
+/// Beyond release (ext=True), returns "M.m.p.postD" where D is distance from
+/// release. Beyond release (ext=False), returns most recent release, "M.m.p".
+inline std::string libint_version_string(bool ext = true) {
+  std::string version = ::libint_version_string(ext);
+  return version;
+}
+
+/// Get the git commit at which library was generated
+/// @return the commit as a 7-char abbreviated string
+inline std::string libint_commit(void) {
+  std::string commit = ::libint_commit();
+  return commit;
+}
+
+/// Literature citation
+/// @return the citation string including description and version
+inline std::string libint_reference(void) {
+  std::string ref = ::libint_reference();
+  return ref;
+}
+
+/// Literature citation DOI
+/// @return the string of DOI for latest tag
+inline std::string libint_reference_doi(void) {
+  std::string ref = ::libint_reference_doi();
+  return ref;
+}
+
+/// BibTeX for citing Libint
+/// @return the string for literature citation
+inline std::string libint_bibtex(void) {
+  std::string ref = ::libint_bibtex();
+  return ref;
+}
+
 }  // namespace libint2
 #endif /* C++ guard */
 

--- a/src/lib/libint/configuration.cc
+++ b/src/lib/libint/configuration.cc
@@ -18,10 +18,45 @@
  *
  */
 
-/* Runtime accessor for the library configuration:
-   integral derivatives, AM, orderings, etc.
-   @return the semicolon-separated strings from CMake components */
-const char* configuration_accessor() {
+const char *configuration_accessor(void) {
   // return "@Libint2_CONFIG_COMPONENTS@";
   return "(nyi)";
+}
+
+void libint_version(int *major, int *minor, int *micro) {
+  *major = -1;
+  *minor = -1;
+  *micro = -1;
+  sscanf(libint_version_string(ext = false), "%d.%d.%d", major, minor, micro);
+}
+
+const char *libint_version_string(bool ext) {
+  if (ext)
+    return "@LIBINT_SORTABLE_VERSION@";
+  else
+    return "@LIBINT_VERSION@";
+}
+
+const char *libint_commit(void) { return "@LIBINT_GIT_COMMIT@"; }
+
+const char *libint_reference(void) {
+  std::string ref;
+  ref =
+      "Libint: A library for the evaluation of molecular integrals of "
+      "many-body operators over Gaussian functions, Version " +
+      std::string(libint_version_string()) +
+      " Edward F. Valeev, http://libint.valeyev.net/";
+  return ref.c_str();
+}
+
+const char *libint_reference_doi(void) {
+  return "10.5281/zenodo.10369117";  // 2.8.0
+}
+
+const char *libint_bibtex(void) {
+  return "@Misc{Libint2,\n  author = {E.~F.~Valeev},\n  title = "
+         "{\\textsc{Libint}: A library for the evaluation of molecular "
+         "integrals of many-body operators over Gaussian functions},\n  "
+         "howpublished = {http://libint.valeyev.net/},\n  note = {version "
+         "@Libint2_VERSION@},\n  year = {@LIBINT_VERSION_YEAR@}\n}\n";
 }

--- a/src/lib/libint/configuration.cc
+++ b/src/lib/libint/configuration.cc
@@ -18,6 +18,11 @@
  *
  */
 
+#include <libint2/util/configuration.h>
+
+#include <cstdio>
+#include <cstring>
+
 const char *configuration_accessor(void) {
   // return "@Libint2_CONFIG_COMPONENTS@";
   return "(nyi)";
@@ -27,7 +32,7 @@ void libint_version(int *major, int *minor, int *micro) {
   *major = -1;
   *minor = -1;
   *micro = -1;
-  sscanf(libint_version_string(ext = false), "%d.%d.%d", major, minor, micro);
+  std::sscanf(libint_version_string(false), "%d.%d.%d", major, minor, micro);
 }
 
 const char *libint_version_string(bool ext) {
@@ -40,23 +45,22 @@ const char *libint_version_string(bool ext) {
 const char *libint_commit(void) { return "@LIBINT_GIT_COMMIT@"; }
 
 const char *libint_reference(void) {
-  std::string ref;
-  ref =
-      "Libint: A library for the evaluation of molecular integrals of "
-      "many-body operators over Gaussian functions, Version " +
-      std::string(libint_version_string()) +
-      " Edward F. Valeev, http://libint.valeyev.net/";
-  return ref.c_str();
+  std::string ref = "Libint: @LIBINT_DESCRIPTION@, Version " +
+                    std::string(libint_version_string(true)) +
+                    " Edward F. Valeev, http://libint.valeyev.net/";
+
+  auto slen = ref.length();
+  char *cref = new char[slen + 1];
+  std::memcpy(cref, ref.c_str(), slen);
+  cref[slen] = '\0';
+  return cref;
 }
 
-const char *libint_reference_doi(void) {
-  return "10.5281/zenodo.10369117";  // 2.8.0
-}
+const char *libint_reference_doi(void) { return "@LIBINT_DOI@"; }
 
 const char *libint_bibtex(void) {
   return "@Misc{Libint2,\n  author = {E.~F.~Valeev},\n  title = "
-         "{\\textsc{Libint}: A library for the evaluation of molecular "
-         "integrals of many-body operators over Gaussian functions},\n  "
+         "{\\textsc{Libint}: @LIBINT_DESCRIPTION@},\n  "
          "howpublished = {http://libint.valeyev.net/},\n  note = {version "
          "@Libint2_VERSION@},\n  year = {@LIBINT_VERSION_YEAR@}\n}\n";
 }

--- a/tests/unit/test.cc
+++ b/tests/unit/test.cc
@@ -66,6 +66,11 @@ int main(int argc, char* argv[]) {
          libint2::configuration_accessor().c_str());
   printf("Supports: dddd=%d mmmm=%d FF=%d\n", libint2::supports("eri_dddd_d0"),
          libint2::supports("eri_mmmm_d0"), libint2::supports("eri_FF_d0"));
+  auto Mmp = libint2::libint_version();
+  printf("Version: Numeric=%s Sortable=%s Commit=%s\n", libint2::libint_version_string(false).c_str(), libint2::libint_version_string(true).c_str(), libint2::libint_commit().c_str());
+  printf("Version: Major=%d minor=%d patch=%d\n", std::get<0>(Mmp), std::get<1>(Mmp), std::get<2>(Mmp));
+  printf("Citation: DOI=%s Ref=%s\n", libint2::libint_reference_doi().c_str(), libint2::libint_reference().c_str());
+  printf("Citation: BibTex=%s\n", libint2::libint_bibtex().c_str());
 
 #ifdef LIBINT_HAS_MPFR
   // default to 256 bits of precision for mpf_class


### PR DESCRIPTION
currently atop #299 . here's the diff of the new stuff: https://github.com/loriab/libint/compare/extras...loriab:libint:intconfig

- [x] This PR
  * presents ints classes and deriv and AM options to user (CMakeLists.txt)
  * processes user options into L2 define variables (int_am.cmake)
  * writes the define variables to config.h.cmake.in
  * provides documentation (largely duplicates CMakeLists.txt) and upgrade helper (INSTALL.md)
- [x] int_am.cmake both 
  - [x] (1) does the defaulting logic that was in configure.ac and ends up in config.h . This adds a couple extra user input checks. The output I think is in good shape -- see the examples below. I can run others if you're curious. 
  - [x] (2) constructs "candidate" vars containing the target AM per class and per deriv for assembling the `eri_ffff_d0` cmake components. This imitates logic that in L2 lives in build_libint.cc. The component-constructing machinery has been reworked for the new component format, and it wasn't too hard to keep it in cmake and avoid a Python dependency. This makes configuration-gen.py redundant.
    The only trouble here is that originally I had used both `--with-max-am=N` & `--with-max-am=N0,N1,N2` in layers as defaults for ints classes. Whereas I'm pretty sure now that the latter has no role in defaulting (other than setting its max to LIBINT_MAX_AM) and is entirely directed at eri3. So the cmake components printed reflect this layered defaulting and likely not the true ints available. (Given the pattern, the cmake components are underpromising, not underdelivering, at least.) I've left this for now in case I'm mistaken again or in case you _prefer_ this defaulting scheme, but probably it should be ripped out in the end to conform strictly with configure.ac/build_libint.cc .
- [x] One potential plumbing bug: `WITH_ONEBODY_[MAX|OPT]_AM` with per-deriv `N0,N1,N2` option is stated in the current docs and parsed by configure.ac into `ONEBODY_MAX_AM_LIST`/`ONEBODY_OPT_AM_LIST` and those defines are processed in build_libint.cc. But there's a handoff missing in `include/libint2/config.h.in` where the LIST never got defined. I've added them in to both the libtool `config.h.in` and the WIP cmake `config.h.cmake.in`.


-------------------------------------------------------------------------

## GHA example

```
> --with-max-am=2,2 --with-eri-max-am=2,2 --with-eri3-max-am=3,2 --enable-eri=1 --enable-eri3=1 --enable-1body=1 --disable-1body-property-derivs --with-multipole-max-order=2

> -DWITH_MAX_AM="2;2" -DWITH_ERI_MAX_AM="2;2" -DWITH_ERI3_MAX_AM="3;2" -DENABLE_ERI=1 -DENABLE_ERI3=1 -DENABLE_ONEBODY=1 -DDISABLE_ONEBODY_PROPERTY_DERIVS=ON -DMULTIPOLE_MAX_ORDER=2
```

part of cmake printout
```
-- Library will satisfy ERI AM components: multipole_dd_d0;onebody_dd_d0;onebody_dd_d1;eri_dddd_d0;eri_dddd_d1;eri_ddF_d0;eri_ddD_d0;eri_ddD_d1;eri_ddf_d0;eri_ddd_d0;eri_ddd_d1

-- Libint Enabled features:
 * general integral, config.h: LIBINT_MAX_AM=2 LIBINT_MAX_AM_LIST=2,2 LIBINT_OPT_AM=2 LIBINT_OPT_AM_LIST=
 * integral class MULTIPOLE derivative 0, max_am 2
 * integral class ONEBODY, config.h: INCLUDE_ONEBODY=1 ONEBODY_MAX_AM= ONEBODY_MAX_AM_LIST= ONEBODY_OPT_AM= ONEBODY_OPT_AM_LIST=
 * integral class ONEBODY derivative 0, max_am 2
 * integral class ONEBODY derivative 1, max_am 2
 * integral class ERI, config.h: INCLUDE_ERI=1 ERI_MAX_AM= ERI_MAX_AM_LIST=2,2 ERI_OPT_AM= ERI_OPT_AM_LIST=
 * integral class ERI derivative 0, max_am 2
 * integral class ERI derivative 1, max_am 2
 * integral class ERI3, config.h: INCLUDE_ERI3=1 ERI3_MAX_AM= ERI3_MAX_AM_LIST=3,2 ERI3_OPT_AM= ERI3_OPT_AM_LIST=
 * integral class ERI3 derivative 0, max_am 3
 * integral class ERI3 derivative 1, max_am 2

-- Libint Disabled features:
 * integral class ERI2, config.h: INCLUDE_ERI2=-1 ERI2_MAX_AM= ERI2_MAX_AM_LIST= ERI2_OPT_AM= ERI2_OPT_AM_LIST=
 * integral class G12, config.h: INCLUDE_G12=-1 G12_MAX_AM= G12_OPT_AM=
 * integral class G12DKH, config.h: INCLUDE_G12DKH=-1 G12DKH_MAX_AM= G12DKH_OPT_AM=
```

compare _AM lines in libtool-generated and cmake-generated config.h
```
include/libint2/config.h:#define LIBINT_MAX_AM 2
include/libint2/config.h:#define LIBINT_MAX_AM_LIST "2,2"
include/libint2/config.h:#define LIBINT_OPT_AM 2
include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI_MAX_AM */
include/libint2/config.h:#define ERI_MAX_AM_LIST "2,2"
include/libint2/config.h:/* #undef ERI_OPT_AM */
include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI3_MAX_AM */
include/libint2/config.h:#define ERI3_MAX_AM_LIST "3,2"
include/libint2/config.h:/* #undef ERI3_OPT_AM */
include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI2_MAX_AM */
include/libint2/config.h:/* #undef ERI2_MAX_AM_LIST */
include/libint2/config.h:/* #undef ERI2_OPT_AM */
include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
include/libint2/config.h:/* #undef G12_MAX_AM */
include/libint2/config.h:/* #undef G12_OPT_AM */
include/libint2/config.h:/* #undef G12DKH_MAX_AM */
include/libint2/config.h:/* #undef G12DKH_OPT_AM */

cmbuild/include/libint2/config.h:#define LIBINT_MAX_AM 2
cmbuild/include/libint2/config.h:#define LIBINT_MAX_AM_LIST "2,2"
cmbuild/include/libint2/config.h:#define LIBINT_OPT_AM 2
cmbuild/include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI_MAX_AM */
cmbuild/include/libint2/config.h:#define ERI_MAX_AM_LIST "2,2"
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI3_MAX_AM */
cmbuild/include/libint2/config.h:#define ERI3_MAX_AM_LIST "3,2"
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI2_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ERI2_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef G12_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef G12_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef G12DKH_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef G12DKH_OPT_AM */
```

-------------------------------------------------------------------------

## empty

```
>
>
```

```
-- Library will satisfy ERI AM components: multipole_gg_d0;multipole_ff_d0;multipole_dd_d0;onebody_gg_d0;onebody_ff_d0;onebody_dd_d0;eri_gggg_d0;eri_ffff_d0;eri_dddd_d0

-- Libint Enabled features:
 * general integral, config.h: LIBINT_MAX_AM=4 LIBINT_MAX_AM_LIST= LIBINT_OPT_AM=3 LIBINT_OPT_AM_LIST=
 * integral class MULTIPOLE derivative 0, max_am 4
 * integral class ONEBODY, config.h: INCLUDE_ONEBODY=0 ONEBODY_MAX_AM= ONEBODY_MAX_AM_LIST= ONEBODY_OPT_AM= ONEBODY_OPT_AM_LIST=
 * integral class ONEBODY derivative 0, max_am 4
 * integral class ERI, config.h: INCLUDE_ERI=0 ERI_MAX_AM= ERI_MAX_AM_LIST= ERI_OPT_AM= ERI_OPT_AM_LIST=
 * integral class ERI derivative 0, max_am 4

-- Libint Disabled features:
 * integral class ERI3, config.h: INCLUDE_ERI3=-1 ERI3_MAX_AM= ERI3_MAX_AM_LIST= ERI3_OPT_AM= ERI3_OPT_AM_LIST=
 * integral class ERI2, config.h: INCLUDE_ERI2=-1 ERI2_MAX_AM= ERI2_MAX_AM_LIST= ERI2_OPT_AM= ERI2_OPT_AM_LIST=
 * integral class G12, config.h: INCLUDE_G12=-1 G12_MAX_AM= G12_OPT_AM=
 * integral class G12DKH, config.h: INCLUDE_G12DKH=-1 G12DKH_MAX_AM= G12DKH_OPT_AM=
```

```
include/libint2/config.h:#define LIBINT_MAX_AM 4
include/libint2/config.h:/* #undef LIBINT_MAX_AM_LIST */
include/libint2/config.h:#define LIBINT_OPT_AM 3
include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI_MAX_AM */
include/libint2/config.h:/* #undef ERI_MAX_AM_LIST */
include/libint2/config.h:/* #undef ERI_OPT_AM */
include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI3_MAX_AM */
include/libint2/config.h:/* #undef ERI3_MAX_AM_LIST */
include/libint2/config.h:/* #undef ERI3_OPT_AM */
include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI2_MAX_AM */
include/libint2/config.h:/* #undef ERI2_MAX_AM_LIST */
include/libint2/config.h:/* #undef ERI2_OPT_AM */
include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
include/libint2/config.h:/* #undef G12_MAX_AM */
include/libint2/config.h:/* #undef G12_OPT_AM */
include/libint2/config.h:/* #undef G12DKH_MAX_AM */
include/libint2/config.h:/* #undef G12DKH_OPT_AM */

cmbuild/include/libint2/config.h:#define LIBINT_MAX_AM 4
cmbuild/include/libint2/config.h:/* #undef LIBINT_MAX_AM_LIST */
cmbuild/include/libint2/config.h:#define LIBINT_OPT_AM 3
cmbuild/include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ERI_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI3_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ERI3_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI2_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ERI2_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef G12_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef G12_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef G12DKH_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef G12DKH_OPT_AM */
```

-------------------------------------------------------------------------

## MPQC4

```
> --with-max-am=6 --with-opt-am=3 --enable-eri3=0 --enable-eri2=0 --enable-eri3-pure-sh --enable-eri2-pure-sh --disable-1body-property-derivs

> -DWITH_MAX_AM=6 -DWITH_OPT_AM=3 -DENABLE_ERI3=0 -DENABLE_ERI2=0 -DERI3_PURE_SH=ON -DERI2_PURE_SH=ON -DDISABLE_ONEBODY_PROPERTY_DERIVS=ON
```

```
-- Library will satisfy ERI AM components: multipole_gg_d0;multipole_ff_d0;multipole_dd_d0;onebody_ii_d0;onebody_hh_d0;onebody_gg_d0;onebody_ff_d0;onebody_dd_d0;eri_iiii_d0;eri_hhhh_d0;eri_gggg_d0;eri_ffff_d0;eri_dddd_d0;eri_iiI_d0;eri_hhI_d0;eri_hhH_d0;eri_ggI_d0;eri_ggH_d0;eri_ggG_d0;eri_ffI_d0;eri_ffH_d0;eri_ffG_d0;eri_ffF_d0;eri_ddI_d0;eri_ddH_d0;eri_ddG_d0;eri_ddF_d0;eri_ddD_d0;eri_II_d0;eri_HH_d0;eri_GG_d0;eri_FF_d0;eri_DD_d0

-- Libint Enabled features:
 * general integral, config.h: LIBINT_MAX_AM=6 LIBINT_MAX_AM_LIST= LIBINT_OPT_AM=3 LIBINT_OPT_AM_LIST=
 * integral class MULTIPOLE derivative 0, max_am 4
 * integral class ONEBODY, config.h: INCLUDE_ONEBODY=0 ONEBODY_MAX_AM= ONEBODY_MAX_AM_LIST= ONEBODY_OPT_AM= ONEBODY_OPT_AM_LIST=
 * integral class ONEBODY derivative 0, max_am 6
 * integral class ERI, config.h: INCLUDE_ERI=0 ERI_MAX_AM= ERI_MAX_AM_LIST= ERI_OPT_AM= ERI_OPT_AM_LIST=
 * integral class ERI derivative 0, max_am 6
 * integral class ERI3, config.h: INCLUDE_ERI3=0 ERI3_MAX_AM= ERI3_MAX_AM_LIST= ERI3_OPT_AM= ERI3_OPT_AM_LIST=
 * integral class ERI3 derivative 0, max_am 6
 * integral class ERI2, config.h: INCLUDE_ERI2=0 ERI2_MAX_AM= ERI2_MAX_AM_LIST= ERI2_OPT_AM= ERI2_OPT_AM_LIST=
 * integral class ERI2 derivative 0, max_am 6

-- Libint Disabled features:
 * integral class G12, config.h: INCLUDE_G12=-1 G12_MAX_AM= G12_OPT_AM=
 * integral class G12DKH, config.h: INCLUDE_G12DKH=-1 G12DKH_MAX_AM= G12DKH_OPT_AM=
```

```
include/libint2/config.h:#define LIBINT_MAX_AM 6
include/libint2/config.h:/* #undef LIBINT_MAX_AM_LIST */
include/libint2/config.h:#define LIBINT_OPT_AM 3
include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI_MAX_AM */
include/libint2/config.h:/* #undef ERI_MAX_AM_LIST */
include/libint2/config.h:/* #undef ERI_OPT_AM */
include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI3_MAX_AM */
include/libint2/config.h:/* #undef ERI3_MAX_AM_LIST */
include/libint2/config.h:/* #undef ERI3_OPT_AM */
include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI2_MAX_AM */
include/libint2/config.h:/* #undef ERI2_MAX_AM_LIST */
include/libint2/config.h:/* #undef ERI2_OPT_AM */
include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
include/libint2/config.h:/* #undef G12_MAX_AM */
include/libint2/config.h:/* #undef G12_OPT_AM */
include/libint2/config.h:/* #undef G12DKH_MAX_AM */
include/libint2/config.h:/* #undef G12DKH_OPT_AM */

cmbuild/include/libint2/config.h:#define LIBINT_MAX_AM 6
cmbuild/include/libint2/config.h:/* #undef LIBINT_MAX_AM_LIST */
cmbuild/include/libint2/config.h:#define LIBINT_OPT_AM 3
cmbuild/include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ERI_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI3_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ERI3_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI2_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ERI2_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef G12_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef G12_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef G12DKH_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef G12DKH_OPT_AM */
```

-------------------------------------------------------------------------

## c-f/psi4 "basic" for windows

```
> --enable-eri=1 --enable-eri3=1 --enable-eri2=1 --enable-1body=2 --enable-g12=1 --disable-1body-property-derivs --with-multipole-max-order=10 --with-g12-max-am=4 --with-eri-max-am=5,4 --with-eri3-max-am=6,5 --with-eri2-max-am=6,5 --with-max-am=6,5

> -DENABLE_ERI=1 -DENABLE_ERI3=1 -DENABLE_ERI2=1 -DENABLE_ONEBODY=2 -DENABLE_G12=1 -DDISABLE_ONEBODY_PROPERTY_DERIVS=ON -DMULTIPOLE_MAX_ORDER=10 -DWITH_G12_MAX_AM=4 -DWITH_ERI_MAX_AM="5;4" -DWITH_ERI3_MAX_AM="6;5" -DWITH_ERI2_MAX_AM="6;5" -DWITH_MAX_AM="6;5;5"
```
Note that literal translation throws an error: "Invalid value for WITH_MAX_AM (6;5). Highest ENABLE_ derivative (2) requires list length 3, not 2." Input isn't technically wrong since list WITH_MAX_AM likely only relevant for ERI3. But in the interest of catching user slips, I'm leaving the check in and adjusting the input to `WITH_MAX_AM="6;5;5"`.


```
-- Library will satisfy ERI AM components: multipole_nn_d0;multipole_mm_d0;multipole_ll_d0;multipole_kk_d0;multipole_ii_d0;multipole_hh_d0;multipole_gg_d0;multipole_ff_d0;multipole_dd_d0;onebody_ii_d0;onebody_hh_d0;onebody_gg_d0;onebody_ff_d0;onebody_dd_d0;onebody_hh_d1;onebody_gg_d1;onebody_ff_d1;onebody_dd_d1;onebody_hh_d2;onebody_gg_d2;onebody_ff_d2;onebody_dd_d2;eri_hhhh_d0;eri_gggg_d0;eri_ffff_d0;eri_dddd_d0;eri_gggg_d1;eri_ffff_d1;eri_dddd_d1;eri_iiI_d0;eri_hhI_d0;eri_hhH_d0;eri_ggI_d0;eri_ggH_d0;eri_ggG_d0;eri_ffI_d0;eri_ffH_d0;eri_ffG_d0;eri_ffF_d0;eri_ddI_d0;eri_ddH_d0;eri_ddG_d0;eri_ddF_d0;eri_ddD_d0;eri_hhH_d1;eri_ggH_d1;eri_ggG_d1;eri_ffH_d1;eri_ffG_d1;eri_ffF_d1;eri_ddH_d1;eri_ddG_d1;eri_ddF_d1;eri_ddD_d1;eri_iii_d0;eri_hhi_d0;eri_hhh_d0;eri_ggi_d0;eri_ggh_d0;eri_ggg_d0;eri_ffi_d0;eri_ffh_d0;eri_ffg_d0;eri_fff_d0;eri_ddi_d0;eri_ddh_d0;eri_ddg_d0;eri_ddf_d0;eri_ddd_d0;eri_hhh_d1;eri_ggh_d1;eri_ggg_d1;eri_ffh_d1;eri_ffg_d1;eri_fff_d1;eri_ddh_d1;eri_ddg_d1;eri_ddf_d1;eri_ddd_d1;eri_II_d0;eri_HH_d0;eri_GG_d0;eri_FF_d0;eri_DD_d0;eri_HH_d1;eri_GG_d1;eri_FF_d1;eri_DD_d1;eri_ii_d0;eri_hh_d0;eri_gg_d0;eri_ff_d0;eri_dd_d0;eri_hh_d1;eri_gg_d1;eri_ff_d1;eri_dd_d1;g12_gggg_d0;g12_ffff_d0;g12_dddd_d0;g12_gggg_d1;g12_ffff_d1;g12_dddd_d1

-- Libint Enabled features:
 * general integral, config.h: LIBINT_MAX_AM=6 LIBINT_MAX_AM_LIST=6,5,5 LIBINT_OPT_AM=4 LIBINT_OPT_AM_LIST=
 * integral class MULTIPOLE derivative 0, max_am 10
 * integral class ONEBODY, config.h: INCLUDE_ONEBODY=2 ONEBODY_MAX_AM= ONEBODY_MAX_AM_LIST= ONEBODY_OPT_AM= ONEBODY_OPT_AM_LIST=
 * integral class ONEBODY derivative 0, max_am 6
 * integral class ONEBODY derivative 1, max_am 5
 * integral class ONEBODY derivative 2, max_am 5
 * integral class ERI, config.h: INCLUDE_ERI=1 ERI_MAX_AM= ERI_MAX_AM_LIST=5,4 ERI_OPT_AM= ERI_OPT_AM_LIST=
 * integral class ERI derivative 0, max_am 5
 * integral class ERI derivative 1, max_am 4
 * integral class ERI3, config.h: INCLUDE_ERI3=1 ERI3_MAX_AM= ERI3_MAX_AM_LIST=6,5 ERI3_OPT_AM= ERI3_OPT_AM_LIST=
 * integral class ERI3 derivative 0, max_am 6
 * integral class ERI3 derivative 1, max_am 5
 * integral class ERI2, config.h: INCLUDE_ERI2=1 ERI2_MAX_AM= ERI2_MAX_AM_LIST=6,5 ERI2_OPT_AM= ERI2_OPT_AM_LIST=
 * integral class ERI2 derivative 0, max_am 6
 * integral class ERI2 derivative 1, max_am 5
 * integral class G12, config.h: INCLUDE_G12=1 G12_MAX_AM=4 G12_OPT_AM=4
 * integral class G12 derivative 0, max_am 4
 * integral class G12 derivative 1, max_am 4

-- Libint Disabled features:
 * integral class G12DKH, config.h: INCLUDE_G12DKH=-1 G12DKH_MAX_AM= G12DKH_OPT_AM=
```
This is an example of how the current CMake defaulting uses the list WITH_MAX_AM to default other classes rather than only using scalar WITH_MAX_AM for defaulting and reserving list WITH_MAX_AM for ERI3 paired: ONEBODY shows max_am=6 for ene and =5 for grad rather than 6 for both. For now, though, this inconsistency is only going to affect the cmake components, not the config.h (comparison below has only the deliberate LIBINT_MAX_AM_LIST difference) or the library.

```
include/libint2/config.h:#define LIBINT_MAX_AM 6
include/libint2/config.h:#define LIBINT_MAX_AM_LIST "6,5"
include/libint2/config.h:#define LIBINT_OPT_AM 4
include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI_MAX_AM */
include/libint2/config.h:#define ERI_MAX_AM_LIST "5,4"
include/libint2/config.h:/* #undef ERI_OPT_AM */
include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI3_MAX_AM */
include/libint2/config.h:#define ERI3_MAX_AM_LIST "6,5"
include/libint2/config.h:/* #undef ERI3_OPT_AM */
include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI2_MAX_AM */
include/libint2/config.h:#define ERI2_MAX_AM_LIST "6,5"
include/libint2/config.h:/* #undef ERI2_OPT_AM */
include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
include/libint2/config.h:#define G12_MAX_AM 4
include/libint2/config.h:#define G12_OPT_AM 4
include/libint2/config.h:/* #undef G12DKH_MAX_AM */
include/libint2/config.h:/* #undef G12DKH_OPT_AM */

cmbuild/include/libint2/config.h:#define LIBINT_MAX_AM 6
cmbuild/include/libint2/config.h:#define LIBINT_MAX_AM_LIST "6,5,5"
cmbuild/include/libint2/config.h:#define LIBINT_OPT_AM 4
cmbuild/include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI_MAX_AM */
cmbuild/include/libint2/config.h:#define ERI_MAX_AM_LIST "5,4"
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI3_MAX_AM */
cmbuild/include/libint2/config.h:#define ERI3_MAX_AM_LIST "6,5"
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI2_MAX_AM */
cmbuild/include/libint2/config.h:#define ERI2_MAX_AM_LIST "6,5"
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
cmbuild/include/libint2/config.h:#define G12_MAX_AM 4
cmbuild/include/libint2/config.h:#define G12_OPT_AM 4
cmbuild/include/libint2/config.h:/* #undef G12DKH_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef G12DKH_OPT_AM */
```

-------------------------------------------------------------------------

## psi4 trial "bigAM" for linux

```
> --enable-eri=2 --enable-eri3=2 --enable-eri2=2 --enable-1body=2 --enable-g12=1 --disable-1body-property-derivs --with-multipole-max-order=10 --with-g12-max-am=4 --with-eri-max-am=7,7,4 --with-eri3-max-am=12,7,5 --with-eri2-max-am=7,7,5 --with-max-am=7,7,5

> -DENABLE_ERI=2 -DENABLE_ERI3=2 -DENABLE_ERI2=2 -DENABLE_ONEBODY=2 -DENABLE_G12=1 -DDISABLE_ONEBODY_PROPERTY_DERIVS=ON -DMULTIPOLE_MAX_ORDER=10 -DWITH_G12_MAX_AM=4 -DWITH_ERI_MAX_AM="7;7;4" -DWITH_ERI3_MAX_AM="12;7;5" -DWITH_ERI2_MAX_AM="7;7;5" -DWITH_MAX_AM="7;7;5"
```

```
-- Library will satisfy ERI AM components: multipole_nn_d0;multipole_mm_d0;multipole_ll_d0;multipole_kk_d0;multipole_ii_d0;multipole_hh_d0;multipole_gg_d0;multipole_ff_d0;multipole_dd_d0;onebody_kk_d0;onebody_ii_d0;onebody_hh_d0;onebody_gg_d0;onebody_ff_d0;onebody_dd_d0;onebody_kk_d1;onebody_ii_d1;onebody_hh_d1;onebody_gg_d1;onebody_ff_d1;onebody_dd_d1;onebody_hh_d2;onebody_gg_d2;onebody_ff_d2;onebody_dd_d2;eri_kkkk_d0;eri_iiii_d0;eri_hhhh_d0;eri_gggg_d0;eri_ffff_d0;eri_dddd_d0;eri_kkkk_d1;eri_iiii_d1;eri_hhhh_d1;eri_gggg_d1;eri_ffff_d1;eri_dddd_d1;eri_gggg_d2;eri_ffff_d2;eri_dddd_d2;eri_kkP_d0;eri_kkO_d0;eri_kkN_d0;eri_kkM_d0;eri_kkL_d0;eri_kkK_d0;eri_iiP_d0;eri_iiO_d0;eri_iiN_d0;eri_iiM_d0;eri_iiL_d0;eri_iiK_d0;eri_iiI_d0;eri_hhP_d0;eri_hhO_d0;eri_hhN_d0;eri_hhM_d0;eri_hhL_d0;eri_hhK_d0;eri_hhI_d0;eri_hhH_d0;eri_ggP_d0;eri_ggO_d0;eri_ggN_d0;eri_ggM_d0;eri_ggL_d0;eri_ggK_d0;eri_ggI_d0;eri_ggH_d0;eri_ggG_d0;eri_ffP_d0;eri_ffO_d0;eri_ffN_d0;eri_ffM_d0;eri_ffL_d0;eri_ffK_d0;eri_ffI_d0;eri_ffH_d0;eri_ffG_d0;eri_ffF_d0;eri_ddP_d0;eri_ddO_d0;eri_ddN_d0;eri_ddM_d0;eri_ddL_d0;eri_ddK_d0;eri_ddI_d0;eri_ddH_d0;eri_ddG_d0;eri_ddF_d0;eri_ddD_d0;eri_kkK_d1;eri_iiK_d1;eri_iiI_d1;eri_hhK_d1;eri_hhI_d1;eri_hhH_d1;eri_ggK_d1;eri_ggI_d1;eri_ggH_d1;eri_ggG_d1;eri_ffK_d1;eri_ffI_d1;eri_ffH_d1;eri_ffG_d1;eri_ffF_d1;eri_ddK_d1;eri_ddI_d1;eri_ddH_d1;eri_ddG_d1;eri_ddF_d1;eri_ddD_d1;eri_hhH_d2;eri_ggH_d2;eri_ggG_d2;eri_ffH_d2;eri_ffG_d2;eri_ffF_d2;eri_ddH_d2;eri_ddG_d2;eri_ddF_d2;eri_ddD_d2;eri_kkp_d0;eri_kko_d0;eri_kkn_d0;eri_kkm_d0;eri_kkl_d0;eri_kkk_d0;eri_iip_d0;eri_iio_d0;eri_iin_d0;eri_iim_d0;eri_iil_d0;eri_iik_d0;eri_iii_d0;eri_hhp_d0;eri_hho_d0;eri_hhn_d0;eri_hhm_d0;eri_hhl_d0;eri_hhk_d0;eri_hhi_d0;eri_hhh_d0;eri_ggp_d0;eri_ggo_d0;eri_ggn_d0;eri_ggm_d0;eri_ggl_d0;eri_ggk_d0;eri_ggi_d0;eri_ggh_d0;eri_ggg_d0;eri_ffp_d0;eri_ffo_d0;eri_ffn_d0;eri_ffm_d0;eri_ffl_d0;eri_ffk_d0;eri_ffi_d0;eri_ffh_d0;eri_ffg_d0;eri_fff_d0;eri_ddp_d0;eri_ddo_d0;eri_ddn_d0;eri_ddm_d0;eri_ddl_d0;eri_ddk_d0;eri_ddi_d0;eri_ddh_d0;eri_ddg_d0;eri_ddf_d0;eri_ddd_d0;eri_kkk_d1;eri_iik_d1;eri_iii_d1;eri_hhk_d1;eri_hhi_d1;eri_hhh_d1;eri_ggk_d1;eri_ggi_d1;eri_ggh_d1;eri_ggg_d1;eri_ffk_d1;eri_ffi_d1;eri_ffh_d1;eri_ffg_d1;eri_fff_d1;eri_ddk_d1;eri_ddi_d1;eri_ddh_d1;eri_ddg_d1;eri_ddf_d1;eri_ddd_d1;eri_hhh_d2;eri_ggh_d2;eri_ggg_d2;eri_ffh_d2;eri_ffg_d2;eri_fff_d2;eri_ddh_d2;eri_ddg_d2;eri_ddf_d2;eri_ddd_d2;eri_KK_d0;eri_II_d0;eri_HH_d0;eri_GG_d0;eri_FF_d0;eri_DD_d0;eri_KK_d1;eri_II_d1;eri_HH_d1;eri_GG_d1;eri_FF_d1;eri_DD_d1;eri_HH_d2;eri_GG_d2;eri_FF_d2;eri_DD_d2;eri_kk_d0;eri_ii_d0;eri_hh_d0;eri_gg_d0;eri_ff_d0;eri_dd_d0;eri_kk_d1;eri_ii_d1;eri_hh_d1;eri_gg_d1;eri_ff_d1;eri_dd_d1;eri_hh_d2;eri_gg_d2;eri_ff_d2;eri_dd_d2;g12_gggg_d0;g12_ffff_d0;g12_dddd_d0;g12_gggg_d1;g12_ffff_d1;g12_dddd_d1

-- Libint Enabled features:
 * general integral, config.h: LIBINT_MAX_AM=7 LIBINT_MAX_AM_LIST=7,7,5 LIBINT_OPT_AM=4 LIBINT_OPT_AM_LIST=
 * integral class MULTIPOLE derivative 0, max_am 10
 * integral class ONEBODY, config.h: INCLUDE_ONEBODY=2 ONEBODY_MAX_AM= ONEBODY_MAX_AM_LIST= ONEBODY_OPT_AM= ONEBODY_OPT_AM_LIST=
 * integral class ONEBODY derivative 0, max_am 7
 * integral class ONEBODY derivative 1, max_am 7
 * integral class ONEBODY derivative 2, max_am 5
 * integral class ERI, config.h: INCLUDE_ERI=2 ERI_MAX_AM= ERI_MAX_AM_LIST=7,7,4 ERI_OPT_AM= ERI_OPT_AM_LIST=
 * integral class ERI derivative 0, max_am 7
 * integral class ERI derivative 1, max_am 7
 * integral class ERI derivative 2, max_am 4
 * integral class ERI3, config.h: INCLUDE_ERI3=2 ERI3_MAX_AM= ERI3_MAX_AM_LIST=12,7,5 ERI3_OPT_AM= ERI3_OPT_AM_LIST=
 * integral class ERI3 derivative 0, max_am 12
 * integral class ERI3 derivative 1, max_am 7
 * integral class ERI3 derivative 2, max_am 5
 * integral class ERI2, config.h: INCLUDE_ERI2=2 ERI2_MAX_AM= ERI2_MAX_AM_LIST=7,7,5 ERI2_OPT_AM= ERI2_OPT_AM_LIST=
 * integral class ERI2 derivative 0, max_am 7
 * integral class ERI2 derivative 1, max_am 7
 * integral class ERI2 derivative 2, max_am 5
 * integral class G12, config.h: INCLUDE_G12=1 G12_MAX_AM=4 G12_OPT_AM=4
 * integral class G12 derivative 0, max_am 4
 * integral class G12 derivative 1, max_am 4

-- Libint Disabled features:
 * integral class G12DKH, config.h: INCLUDE_G12DKH=-1 G12DKH_MAX_AM= G12DKH_OPT_AM=
```

```
include/libint2/config.h:#define LIBINT_MAX_AM 7
include/libint2/config.h:#define LIBINT_MAX_AM_LIST "7,7,5"
include/libint2/config.h:#define LIBINT_OPT_AM 4
include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI_MAX_AM */
include/libint2/config.h:#define ERI_MAX_AM_LIST "7,7,4"
include/libint2/config.h:/* #undef ERI_OPT_AM */
include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI3_MAX_AM */
include/libint2/config.h:#define ERI3_MAX_AM_LIST "12,7,5"
include/libint2/config.h:/* #undef ERI3_OPT_AM */
include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
include/libint2/config.h:/* #undef ERI2_MAX_AM */
include/libint2/config.h:#define ERI2_MAX_AM_LIST "7,7,5"
include/libint2/config.h:/* #undef ERI2_OPT_AM */
include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
include/libint2/config.h:#define G12_MAX_AM 4
include/libint2/config.h:#define G12_OPT_AM 4
include/libint2/config.h:/* #undef G12DKH_MAX_AM */
include/libint2/config.h:/* #undef G12DKH_OPT_AM */

cmbuild/include/libint2/config.h:#define LIBINT_MAX_AM 7
cmbuild/include/libint2/config.h:#define LIBINT_MAX_AM_LIST "7,7,5"
cmbuild/include/libint2/config.h:#define LIBINT_OPT_AM 4
cmbuild/include/libint2/config.h:/* #undef LIBINT_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_MAX_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ONEBODY_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI_MAX_AM */
cmbuild/include/libint2/config.h:#define ERI_MAX_AM_LIST "7,7,4"
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI3_MAX_AM */
cmbuild/include/libint2/config.h:#define ERI3_MAX_AM_LIST "12,7,5"
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI3_OPT_AM_LIST */
cmbuild/include/libint2/config.h:/* #undef ERI2_MAX_AM */
cmbuild/include/libint2/config.h:#define ERI2_MAX_AM_LIST "7,7,5"
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM */
cmbuild/include/libint2/config.h:/* #undef ERI2_OPT_AM_LIST */
cmbuild/include/libint2/config.h:#define G12_MAX_AM 4
cmbuild/include/libint2/config.h:#define G12_OPT_AM 4
cmbuild/include/libint2/config.h:/* #undef G12DKH_MAX_AM */
cmbuild/include/libint2/config.h:/* #undef G12DKH_OPT_AM */
```

-------------------------------------------------------------------------