### PR TITLE
fix CI for setuptools=69

### DIFF
--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -8,7 +8,7 @@ project(Libint LANGUAGES CXX C)
 # Set Libint version ===================================================================================================
 set(LIBINT_MAJOR_VERSION 2)
 set(LIBINT_MINOR_VERSION 8)
-set(LIBINT_MICRO_VERSION 1)
+set(LIBINT_MICRO_VERSION 1)  # Sync this with python/CMakeLists.txt
 set(LIBINT_BUILDID )
 set(LIBINT_VERSION "${LIBINT_MAJOR_VERSION}.${LIBINT_MINOR_VERSION}.${LIBINT_MICRO_VERSION}")
 if (LIBINT_BUILDID)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,6 +5,11 @@ else()
 endif()
 cmake_policy(SET CMP0079 NEW)
 
+if(NOT DEFINED LIBINT_VERSION)
+    # for indep bld of project(libint2-python), version not available from project(Libint2)
+    set(LIBINT_VERISON "2.8.1")  # for version for setup.py from libtool+cmake
+endif()
+
 project(libint2-python)
 
 if (NOT TARGET Python::Module)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_policy(SET CMP0079 NEW)
 
 if(NOT DEFINED LIBINT_VERSION)
     # for indep bld of project(libint2-python), version not available from project(Libint2)
-    set(LIBINT_VERISON "2.8.1")  # for version for setup.py from libtool+cmake
+    set(LIBINT_VERSION "2.8.1")  # for version for setup.py from libtool+cmake
 endif()
 
 project(libint2-python)


### PR DESCRIPTION
As diagnosed in https://github.com/evaleev/libint/pull/318#issuecomment-1889626192, the latest setuptools doesn't like the empty version present in an independent cmake run of the python project. This mends it, albeit with another hand-sync. pulling out version to an external file would be better, but libtool+cmake already has 2 places to edit version, so I kept the file structure simple and make it 3 places to edit. cmake+cmake is cleaner.