### PR TITLE
fix BOOST_PP-related dispatch bug that affects 3-center derivatives when configured with `--with-max-am=X --with-eri3-max-am=Y`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -105,7 +105,7 @@ jobs:
       shell: bash
       working-directory: ${{github.workspace}}/build/compiler
       run: |
-        CPPFLAGS="-I$EIGEN3_INCLUDE_DIR" CXXFLAGS="-std=c++11 -Wno-enum-compare" ${{github.workspace}}/configure --with-max-am=2,2 --with-eri-max-am=2,2 --with-eri3-max-am=3,2 --enable-eri=1 --enable-eri3=1 --enable-1body=1 --disable-1body-property-derivs --with-multipole-max-order=2
+        CPPFLAGS="-I$EIGEN3_INCLUDE_DIR" CXXFLAGS="-std=c++11 -Wno-enum-compare" ${{github.workspace}}/configure --with-max-am=2,1 --with-eri-max-am=2,2 --with-eri3-max-am=3,2 --enable-eri=1 --enable-eri3=1 --enable-1body=1 --disable-1body-property-derivs --with-multipole-max-order=2
         make -j3
         make check
         cd src/bin/test_eri && ./stdtests.pl && cd ../../..

--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -395,8 +395,13 @@ add_test(NAME libint2/eritest/run0
         COMMAND $<TARGET_FILE:eritest-libint2> 0 2)
 set_tests_properties(libint2/eritest/run0
         PROPERTIES FIXTURES_REQUIRED LIBINT2_ERITEST_EXEC)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")  # OK to run l=2 gradients with optimization
+  set(LIBINT2_ERITEST_RUN1_LMAX 1)
+else()
+  set(LIBINT2_ERITEST_RUN1_LMAX 2)
+endif()
 add_test(NAME libint2/eritest/run1
-        COMMAND $<TARGET_FILE:eritest-libint2> 1 1)
+        COMMAND $<TARGET_FILE:eritest-libint2> 1 ${LIBINT2_ERITEST_RUN1_LMAX})
 set_tests_properties(libint2/eritest/run1
         PROPERTIES FIXTURES_REQUIRED LIBINT2_ERITEST_EXEC)
 add_test(NAME libint2/eritest/run2

--- a/include/libint2/engine.impl.h
+++ b/include/libint2/engine.impl.h
@@ -1827,13 +1827,16 @@ __libint2_engine_inline const Engine::target_ptr_vec& Engine::compute2(
         /// lmax might be center dependent
         int ket_lmax = hard_lmax_;
         switch (deriv_order_) {
-#define BOOST_PP_NBODYENGINE_MCR8(r, data, i, elem)                      \
-  case i:                                                                \
-    BOOST_PP_IF(                                                         \
-        BOOST_PP_IS_1(BOOST_PP_CAT(                                      \
-            LIBINT2_CENTER_DEPENDENT_MAX_AM_3eri,                        \
-            BOOST_PP_IIF(BOOST_PP_GREATER(i, 0), i, BOOST_PP_EMPTY()))), \
-        ket_lmax = hard_default_lmax_, BOOST_PP_EMPTY());                \
+          // N.B. notice extra PP_CAT to avoid using
+          // LIBINT2_CENTER_DEPENDENT_MAX_AM_3eri as a subtoken which gets
+          // expanded too early ... i.e. PP_CAT is "not associative"
+#define BOOST_PP_NBODYENGINE_MCR8(r, data, i, elem)                            \
+  case i:                                                                      \
+    BOOST_PP_IF(BOOST_PP_IS_1(BOOST_PP_CAT(                                    \
+                    LIBINT2_CENTER_DEPENDENT_MAX_AM_,                          \
+                    BOOST_PP_CAT(3eri, BOOST_PP_IIF(BOOST_PP_GREATER(i, 0), i, \
+                                                    BOOST_PP_EMPTY())))),      \
+                ket_lmax = hard_default_lmax_, BOOST_PP_EMPTY());              \
     break;
 
           BOOST_PP_LIST_FOR_EACH_I(BOOST_PP_NBODYENGINE_MCR8, _,

--- a/include/libint2/engine.impl.h
+++ b/include/libint2/engine.impl.h
@@ -1170,7 +1170,9 @@ __libint2_engine_inline const Engine::target_ptr_vec& Engine::compute2(
           tket2.ncontr() == 1) &&
          "generally-contracted shells are not yet supported");
 
-  // angular momentum limit obeyed?
+  // angular momentum limit obeyed? can only be fully checked in
+  // braket-dependent code, here only do a basic test that does not guarantee
+  // that the shell-set can be computed
   assert(tbra1.contr[0].l <= lmax_ && "the angular momentum limit is exceeded");
   assert(tbra2.contr[0].l <= lmax_ && "the angular momentum limit is exceeded");
   assert(tket1.contr[0].l <= lmax_ && "the angular momentum limit is exceeded");
@@ -1812,6 +1814,14 @@ __libint2_engine_inline const Engine::target_ptr_vec& Engine::compute2(
     size_t buildfnidx;
     switch (braket_) {
       case BraKet::xx_xx:
+        assert(bra1.contr[0].l <= hard_lmax_ &&
+               "the angular momentum limit is exceeded");
+        assert(bra2.contr[0].l <= hard_lmax_ &&
+               "the angular momentum limit is exceeded");
+        assert(ket1.contr[0].l <= hard_lmax_ &&
+               "the angular momentum limit is exceeded");
+        assert(ket2.contr[0].l <= hard_lmax_ &&
+               "the angular momentum limit is exceeded");
         buildfnidx =
             ((bra1.contr[0].l * hard_lmax_ + bra2.contr[0].l) * hard_lmax_ +
              ket1.contr[0].l) *
@@ -1846,6 +1856,12 @@ __libint2_engine_inline const Engine::target_ptr_vec& Engine::compute2(
             assert(false && "missing case in switch");
             abort();
         }
+        assert(bra1.contr[0].l <= hard_lmax_ &&
+               "the angular momentum limit is exceeded");
+        assert(ket1.contr[0].l <= ket_lmax &&
+               "the angular momentum limit is exceeded");
+        assert(ket2.contr[0].l <= ket_lmax &&
+               "the angular momentum limit is exceeded");
         buildfnidx = (bra1.contr[0].l * ket_lmax + ket1.contr[0].l) * ket_lmax +
                      ket2.contr[0].l;
 #ifdef ERI3_PURE_SH
@@ -1857,6 +1873,10 @@ __libint2_engine_inline const Engine::target_ptr_vec& Engine::compute2(
       } break;
 
       case BraKet::xs_xs:
+        assert(bra1.contr[0].l <= hard_lmax_ &&
+               "the angular momentum limit is exceeded");
+        assert(ket1.contr[0].l <= hard_lmax_ &&
+               "the angular momentum limit is exceeded");
         buildfnidx = bra1.contr[0].l * hard_lmax_ + ket1.contr[0].l;
 #ifdef ERI2_PURE_SH
         if (bra1.contr[0].l > 1)


### PR DESCRIPTION
resolves #308 