### PR TITLE
AM symbols list

### DIFF
--- a/export/cmake/configuration-gen.py
+++ b/export/cmake/configuration-gen.py
@@ -21,7 +21,7 @@ g12_max_am = [4, 4]
 
 # >>>  End user edit
 
-amstr = "SPDFGHIKLMNOPQRTUVWXYZ"
+amstr = "SPDFGHIKLMNOQRTUVWXYZ"
 components = [orderings]
 
 # multipole

--- a/include/libint2/shell.h
+++ b/include/libint2/shell.h
@@ -217,7 +217,7 @@ struct Shell {
   /// `l=0`, `p` for `l=1`, etc.
   /// @throw std::invalid_argument if \c l is greater than 19
   static char am_symbol(size_t l) {
-    static char lsymb[] = "spdfghikmnoqrtuvwxyz";
+    static char lsymb[] = "spdfghiklmnoqrtuvwxyz";
     assert(l <= 19);
     return lsymb[l];
   }

--- a/src/bin/test_eri/time_eri.cc
+++ b/src/bin/test_eri/time_eri.cc
@@ -135,7 +135,7 @@ std::string usage() {
 }
 
 std::string am2label(unsigned int l) {
-  static char labels[] = "spdfghiklmoqrtuvwxyz";
+  static char labels[] = "spdfghiklmnoqrtuvwxyz";
   std::ostringstream oss;
   oss << labels[l];
   return oss.str();


### PR DESCRIPTION
I think one `n` is missing, one `l` is missing, and one `p` too many. I checked p13 of https://archive2.iupap.org/wp-content/uploads/2014/05/A4.pdf that you linked over at BSE, and `n` and `l` are present. I'm building an AM=12, but I don't know of any problems associated with this.