### PR TITLE
l->symbol maps condensed to 1 definition for non-Python code

### DIFF
--- a/include/libint2/config.h.in
+++ b/include/libint2/config.h.in
@@ -321,4 +321,7 @@
 #define LIBINT_MAYBE_UNUSED
 #endif
 
+/* maps angular momentum to the corresponding symbol: 0 -> s, 1 -> p, etc. */
+#define LIBINT_AM2SYMBOL "spdfghiklmnoqrtuvwxyz"
+
 #endif /* header guard */

--- a/include/libint2/shell.h
+++ b/include/libint2/shell.h
@@ -27,6 +27,7 @@
 #endif
 
 #include <libint2.h>
+#include <libint2/config.h>
 #include <libint2/util/small_vector.h>
 
 #include <array>
@@ -809,10 +810,10 @@ struct Shell {
   /// @param l angular momentum quantum number
   /// @return (lower-case) letter symbol corresponding to @p l ; e.g., `s` for
   /// `l=0`, `p` for `l=1`, etc.
-  /// @throw std::invalid_argument if \c l is greater than 19
+  /// @throw std::invalid_argument if \c l is greater than 20
   static char am_symbol(size_t l) {
-    static char lsymb[] = "spdfghiklmnoqrtuvwxyz";
-    assert(l <= 19);
+    assert(l <= sizeof(LIBINT_AM2SYMBOL) - 1);
+    static char lsymb[] = LIBINT_AM2SYMBOL;
     return lsymb[l];
   }
 
@@ -842,30 +843,32 @@ struct Shell {
         return 6;
       case 'K':
         return 7;
-      case 'M':
+      case 'L':
         return 8;
-      case 'N':
+      case 'M':
         return 9;
-      case 'O':
+      case 'N':
         return 10;
-      case 'Q':
+      case 'O':
         return 11;
-      case 'R':
+      case 'Q':
         return 12;
-      case 'T':
+      case 'R':
         return 13;
-      case 'U':
+      case 'T':
         return 14;
-      case 'V':
+      case 'U':
         return 15;
-      case 'W':
+      case 'V':
         return 16;
-      case 'X':
+      case 'W':
         return 17;
-      case 'Y':
+      case 'X':
         return 18;
-      case 'Z':
+      case 'Y':
         return 19;
+      case 'Z':
+        return 20;
       default:
         throw std::invalid_argument{"invalid angular momentum label"};
     }

--- a/src/bin/libint/default_params.cc
+++ b/src/bin/libint/default_params.cc
@@ -198,10 +198,6 @@ TaskParameters::TaskParameters()
 
 //////////
 
-const char
-    libint2::StaticDefinitions::am_letters[StaticDefinitions::num_am_letters +
-                                           1] = "spdfghiklm";
-
 std::string libint2::label_to_funcname(const std::string& label) {
   // Do not prepend compute as it messes up the API prefix functionality.
 #if 0

--- a/src/bin/libint/default_params.h
+++ b/src/bin/libint/default_params.h
@@ -297,16 +297,6 @@ class TaskParameters {
   }
 };
 
-/// Static parameters
-struct StaticDefinitions {
-  /// basis functions with angular momenta 0 .. 9 are represented by these
-  /// letters higher angular momenta are expressed by replacing digits in their
-  /// base-10 representation with the corresponding letters
-  static const unsigned int num_am_letters = 10;
-  /// am -> char conversion
-  static const char am_letters[num_am_letters + 1];
-};
-
 /// Converts a label, e.g. name of the target node, to the name of the function
 /// to compute it
 std::string label_to_funcname(const std::string& label);

--- a/src/bin/libint/gauss.cc
+++ b/src/bin/libint/gauss.cc
@@ -68,12 +68,13 @@ std::array<LIBINT2_UINT_LEAST64, OriginDerivative<3u>::max_deriv + 1>
 namespace {
 std::string am_to_symbol(unsigned int l, bool contracted) {
   std::string result;
+  const size_t lmax_plus_1 = sizeof(LIBINT_AM2SYMBOL) - 1;
   do {
-    const unsigned int digit = l % 10u;
-    char letter = StaticDefinitions::am_letters[digit];
+    const unsigned int digit = l % lmax_plus_1;
+    char letter = LIBINT_AM2SYMBOL[digit];
     if (contracted) letter = toupper(letter);
     result.insert(result.begin(), letter);
-    l /= 10;
+    l /= lmax_plus_1;
   } while (l != 0);
 
   return result;

--- a/src/bin/libint/test.cc
+++ b/src/bin/libint/test.cc
@@ -167,6 +167,18 @@ void RunTest(Callback test, const std::string& descr, std::ostream& os) {
 }
 
 void test0() {
+  // test CGShell labels
+  if (CGShell(0).label() != "s")
+    throw ProgrammingError("CGShell::label() failed for l=0");
+  if (CGShell(20).label() != "z")
+    throw ProgrammingError("CGShell::label() failed for l=20");
+  if (CGShell(21).label() != "ps")
+    throw ProgrammingError("CGShell::label() failed for l=21");
+  if (CGShell(22).label() != "pp")
+    throw ProgrammingError("CGShell::label() failed for l=22");
+  if (CGShell(42).label() != "ds")
+    throw ProgrammingError("CGShell::label() failed for l=42");
+
   std::shared_ptr<TwoPRep_11_11_sq> pppp_quartet =
       TwoPRep_11_11_sq::Instance(sh_p, sh_p, sh_p, sh_p, 0u);
   std::shared_ptr<DGVertex> pppp_ptr =

--- a/src/bin/test_eri/time_eri.cc
+++ b/src/bin/test_eri/time_eri.cc
@@ -135,7 +135,8 @@ std::string usage() {
 }
 
 std::string am2label(unsigned int l) {
-  static char labels[] = "spdfghiklmnoqrtuvwxyz";
+  assert(l <= sizeof(LIBINT_AM2SYMBOL) - 1);
+  static char labels[] = LIBINT_AM2SYMBOL;
   std::ostringstream oss;
   oss << labels[l];
   return oss.str();

--- a/tests/eri/test.cc
+++ b/tests/eri/test.cc
@@ -98,16 +98,16 @@ libint2::FmEval_Taylor<double, 6> fmeval_taylor(std::max(LIBINT_MAX_AM, 4) * 4 +
                                                 1e-15);
 
 namespace {
-const char am_letters[] = "spdfghiklm";
 
 std::string am_to_symbol(unsigned int l, bool contracted = false) {
   std::string result;
+  const size_t lmax_plus_1 = sizeof(LIBINT_AM2SYMBOL) - 1;
   do {
-    const unsigned int digit = l % 10u;
-    char letter = am_letters[digit];
+    const unsigned int digit = l % lmax_plus_1;
+    char letter = LIBINT_AM2SYMBOL[digit];
     if (contracted) letter = toupper(letter);
     result.insert(result.begin(), letter);
-    l /= 10;
+    l /= lmax_plus_1;
   } while (l != 0);
 
   return result;


### PR DESCRIPTION
includes additional fixes/improvements:
- `Shell::am_symbol_to_l` fixed
- am symbols for high l switched from base-10 to base-20 notation ... e.g. instead of `l`, `m`, `ps`, `pp` the new labels  goes as `y`, `z`, `ps`, `pp`, etc.

