### PR TITLE
Allow access to Cartesian multipole derivatives

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,7 +226,7 @@ case $enableval in
   ;;
 esac
 ])
-if test X$DISABLE_ONEBODY_PROPERTY_DERIVS != 0; then
+if test $DISABLE_ONEBODY_PROPERTY_DERIVS != 0; then
   AC_DEFINE(DISABLE_ONEBODY_PROPERTY_DERIVS)
 fi
 

--- a/src/bin/libint/build_libint.cc
+++ b/src/bin/libint/build_libint.cc
@@ -316,9 +316,9 @@ void build_onebody_1b_1k(std::ostream& os, std::string label,
   // derivatives of spherical multipole integrals are not implemented
   {
     if (std::is_same<_OperType, SphericalMultipoleOper>::value &&
-        deriv_level > 0)
-      throw std::invalid_argument(
-          "derivatives of spherical multipole ints are not yet implemented");
+        deriv_level > 0) return;
+      // throw std::invalid_argument(
+      //     "derivatives of spherical multipole ints are not yet implemented");
   }
 
   //


### PR DESCRIPTION
Addresses Issue #236 by enabling access to Cartesian one-body property derivatives.

Acts similarly to the `DISABLE_ONEBODY_PROPERTY_DERIVS` by just skipping formation of the files if SphericalMultipoleOper && deriv_level > 0 is detected.
```
#ifdef DISABLE_ONEBODY_PROPERTY_DERIVS
  const auto property_operator =
      !(std::is_same<_OperType, OverlapOper>::value ||
        std::is_same<_OperType, KineticOper>::value ||
        std::is_same<_OperType, ElecPotOper>::value);
  if (property_operator && deriv_level > 0) return;
#endif
```

Obviously, the configure.ac file has no effect for when Libint is switched to CMake, but I've changed the build_libint.cc with Lori's branch new-cmake-2023-take2-b with Psi4 before and this works with the change as well.

In response to @loriab  Issue #236, I am able to match Psi4's McMurchie-Davidson dipole derivatives through a separate implementation in the GitHub repo Quax (https://github.com/EricaCMitchell/Quax/blob/dipoles/quax/integrals/libint_interface.cc). So the dipole derivative ints Psi4 is seeking may just be a small issue on the Psi4 side or fixed by improvements to Libint since the issue was raised.