### PR TITLE
Fixes Molden file generation for solid harmonic bases

### DIFF
--- a/include/libint2/lcao/molden.h
+++ b/include/libint2/lcao/molden.h
@@ -296,10 +296,22 @@ class Export {
           const auto pure = shell.contr[c].pure;
           if (pure) {
             int m;
+            // Molden only handles Cartesian p shells, thus remap solid-harmonic
+            // p shells to Cartesians:
+            // - CCA: solid harmonics {y, z, x} -> Cartesian {x, y, z}
+            // - Gaussian: solid harmonics {z, x, y} -> Cartesian {x, y, z}
             if (l == 1) {
-              ao_map_[ao_molden]     = ao + 2;
+#if LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_STANDARD
+              ao_map_[ao_molden] = ao + 2;
               ao_map_[ao_molden + 1] = ao;
               ao_map_[ao_molden + 2] = ao + 1;
+#elif LIBINT_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
+              ao_map_[ao_molden] = ao + 1;
+              ao_map_[ao_molden + 1] = ao + 2;
+              ao_map_[ao_molden + 2] = ao;
+#else
+#error "unknown value of LIBINT_SHGSHELL_ORDERING"
+#endif
               ao_molden += 3;
             } else {
               FOR_SOLIDHARM_MOLDEN(l, m)

--- a/include/libint2/lcao/molden.h
+++ b/include/libint2/lcao/molden.h
@@ -300,19 +300,18 @@ class Export {
           const auto pure = shell.contr[c].pure;
           if (pure) {
             int m;
-            FOR_SOLIDHARM_MOLDEN(l, m)
-            const auto ao_in_shell = libint2::INT_SOLIDHARMINDEX(l, m);
-            ao_map_[ao_molden] = ao + ao_in_shell;
-            ++ao_molden;
-            END_FOR_SOLIDHARM_MOLDEN
-            ao += 2 * l + 1;
-          } else {
-            int i, j, k;
-            FOR_CART_MOLDEN(i, j, k, l)
-            const auto ao_in_shell = INT_CARTINDEX(l, i, j);
-            ao_map_[ao_molden] = ao + ao_in_shell;
-            ++ao_molden;
-            END_FOR_CART_MOLDEN
+            if (l == 1) {
+              ao_map_[ao_molden]     = ao + 2;
+              ao_map_[ao_molden + 1] = ao;
+              ao_map_[ao_molden + 2] = ao + 1;
+              ao_molden += 3;
+            } else {
+              FOR_SOLIDHARM_MOLDEN(l, m)
+              const auto ao_in_shell = libint2::INT_SOLIDHARMINDEX(l, m);
+              ao_map_[ao_molden] = ao + ao_in_shell;
+              ++ao_molden;
+              END_FOR_SOLIDHARM_MOLDEN
+            }
             ao += INT_NCART(l);
           }
         }  // contraction loop

--- a/include/libint2/lcao/molden.h
+++ b/include/libint2/lcao/molden.h
@@ -251,10 +251,6 @@ class Export {
 
         switch (contr.l) {
           case 1:
-            if (contr.pure)
-              throw std::logic_error(
-                  "molden::Export cannot handle solid harmonics p shells");
-            break;
           case 2:
           case 3:
           case 4: {


### PR DESCRIPTION
Initialization of the `ao_map_` did not check for the special case `l==1` when using pure solid harmonic bases, resulting in an incorrect order of the coefficients corresponding to all p-shells.

This PR solves the issue.