### PR TITLE
WIP: Compiler compatibility fixes to version 1

### DIFF
--- a/src/bin/libint/build_libint.c
+++ b/src/bin/libint/build_libint.c
@@ -59,7 +59,7 @@ char *real_type;   /*--- C type for real numbers ---*/
 int libint_stack_size[MAX_AM/2+1];
 LibintParams_t Params;
 
-void punt();
+void punt(char* str);
 extern void emit_vrr_build();
 extern void emit_vrr_build_macro();
 extern void emit_order();

--- a/src/bin/libint/emit_vrr_build.c
+++ b/src/bin/libint/emit_vrr_build.c
@@ -30,8 +30,8 @@ extern FILE *outfile, *vrr_header;
 extern void punt(char *);
 extern LibintParams_t Params;
 
-static void declare_localv();
-static void define_localv();
+static void declare_localv(int a, int k1max, int k2max, int k3max, FILE *code);
+static void define_localv(int a, int foo, int k1max, int k2max, int k3max, FILE *code);
 
 static char **k1, **k2, **k3;
 


### PR DESCRIPTION
Version 1.2.1 fails to compile with GCC 15.0.1, since some functions' forward declarations are inconsistent.

This PR fixes these declarations, allowing the code to compile correctly with up-to-date compilers.