### PR TITLE
[cmake] introduce `libint2_cxx-static`

### DIFF
--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -322,12 +322,6 @@ install(TARGETS libint2 EXPORT libint2
 
 add_subdirectory(include)
 
-if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
-  set(int2_library libint2-static)
-else()
-  set(int2_library libint2)
-endif()
-
 # install basis set library
 if(MSVC)
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/lib/basis
@@ -345,40 +339,40 @@ endif()
 # LibintCXX library ====================================================================================================
 
 if (LIBINT_HAS_CXX_API)
-  add_library(libint2_cxx INTERFACE)
-  target_compile_features(libint2_cxx INTERFACE "cxx_std_11")
-  target_link_libraries(libint2_cxx INTERFACE ${int2_library} libint2_Eigen)
+  add_library(libint2_cxx_prerequisites INTERFACE)
+  target_compile_features(libint2_cxx_prerequisites INTERFACE "cxx_std_11")
+  target_link_libraries(libint2_cxx_prerequisites INTERFACE libint2_Eigen)
   if (LIBINT_HAS_SYSTEM_BOOST_PREPROCESSOR_VARIADICS)
-      target_link_libraries(libint2_cxx INTERFACE Boost::headers)
+      target_link_libraries(libint2_cxx_prerequisites INTERFACE Boost::headers)
   endif(LIBINT_HAS_SYSTEM_BOOST_PREPROCESSOR_VARIADICS)
-    if(WIN32)
-      # Windows does not include <cmath> constants, unless _USE_MATH_DEFINES is defined.
+  if(WIN32)
+    # Windows does not include <cmath> constants, unless _USE_MATH_DEFINES is defined.
+    target_compile_definitions(
+      libint2_cxx
+      INTERFACE
+        _USE_MATH_DEFINES
+    )
+    if(MSVC)
+      # _CRT_* to squash some getenv, strdup, strncpy, ctime, fopen warnings
       target_compile_definitions(
         libint2_cxx
         INTERFACE
-          _USE_MATH_DEFINES
+        _CRT_NONSTDC_NO_DEPRECATE
+        _CRT_NONSTDC_NO_WARNINGS
+        _CRT_SECURE_NO_WARNINGS
       )
-      if(MSVC)
-        # _CRT_* to squash some getenv, strdup, strncpy, ctime, fopen warnings
-        target_compile_definitions(
-          libint2_cxx
-          INTERFACE
-            _CRT_NONSTDC_NO_DEPRECATE
-            _CRT_NONSTDC_NO_WARNINGS
-            _CRT_SECURE_NO_WARNINGS
-          )
-        # Set the exception handling model
-        target_compile_options(
-          libint2_cxx
-          INTERFACE
-            "/EHsc"
-          )
-      endif()
+      # Set the exception handling model
+      target_compile_options(
+        libint2_cxx
+        INTERFACE
+          "/EHsc"
+      )
     endif()
+  endif()
   get_filename_component(DATADIR_ABSOLUTE "${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_DATADIR}" ABSOLUTE)
-  target_compile_definitions(libint2_cxx INTERFACE
-          $<BUILD_INTERFACE:SRCDATADIR="${PROJECT_SOURCE_DIR}/lib/basis">
-    )
+  target_compile_definitions(libint2_cxx_prerequisites INTERFACE
+        $<BUILD_INTERFACE:SRCDATADIR="${PROJECT_SOURCE_DIR}/lib/basis">
+  )
   if (NOT MSVC)
       # TODO fix the DATADIR define escaping on Windows
       # * below works fine in tests
@@ -386,22 +380,36 @@ if (LIBINT_HAS_CXX_API)
       # * prefix replacement in conda used instead on Windows
       # * LIBINT2_INSTALL_DATADIR -> LIBINT2_INSTALL_BASISDIR
       target_compile_definitions(
-        libint2_cxx
+        libint2_cxx_prerequisites
         INTERFACE
           $<INSTALL_INTERFACE:DATADIR="\$\{_IMPORT_PREFIX\}/${LIBINT2_INSTALL_DATADIR}">
         )
   endif()
-  # Add library to the list of installed components
-  install(TARGETS libint2_cxx EXPORT libint2
+
+  set(LIBINT2_CXX_LIBS_TO_INSTALL libint2_cxx_prerequisites)
+
+  add_library(libint2_cxx INTERFACE)
+  target_link_libraries(libint2_cxx INTERFACE libint2_cxx_prerequisites libint2)
+  list(APPEND LIBINT2_CXX_LIBS_TO_INSTALL libint2_cxx)
+  # Alias libint2_cxx -> Libint2::cxx for in-source builds
+  add_library(Libint2::cxx ALIAS libint2_cxx)
+  if (LIBINT2_BUILD_SHARED_AND_STATIC_LIBS)
+    add_library(libint2_cxx-static INTERFACE)
+    target_link_libraries(libint2_cxx-static INTERFACE libint2_cxx_prerequisites libint2-static)
+    list(APPEND LIBINT2_CXX_LIBS_TO_INSTALL libint2_cxx-static)
+    # Alias libint2_cxx-static -> Libint2::cxx-static for in-source builds
+    add_library(Libint2::cxx-static ALIAS libint2_cxx-static)
+  endif()
+
+  # Add cxx librar{y,ies} and prereqs to the list of installed components
+  install(TARGETS ${LIBINT2_CXX_LIBS_TO_INSTALL} EXPORT libint2
           COMPONENT cxx
           RUNTIME DESTINATION "${LIBINT2_INSTALL_BINDIR}"
           LIBRARY DESTINATION "${LIBINT2_INSTALL_LIBDIR}"
           ARCHIVE DESTINATION "${LIBINT2_INSTALL_LIBDIR}"
           # includes are installed by the include/CMakeLists.txt.include.export
           # INCLUDES DESTINATION "${LIBINT2_INSTALL_INCLUDEDIR}"
-          )
-  # Alias libint2_cxx -> Libint2::cxx for in-source builds
-  add_library(Libint2::cxx ALIAS libint2_cxx)
+  )
 endif(LIBINT_HAS_CXX_API)
 
 # Tests ================================================================================================================
@@ -410,7 +418,7 @@ enable_testing(true)
 add_custom_target_subproject(libint2 check USES_TERMINAL COMMAND ${CMAKE_CTEST_COMMAND} -V -R "libint2/")
 
 add_executable(eritest-libint2 EXCLUDE_FROM_ALL tests/eri/test.cc)
-target_link_libraries(eritest-libint2 ${int2_library})
+target_link_libraries(eritest-libint2 libint2)
 target_include_directories(eritest-libint2 PRIVATE ${PROJECT_SOURCE_DIR}/tests/eri)
 if(WIN32)
   # TODO on future target pass, def should be added to the L2 target, not added to test
@@ -571,7 +579,7 @@ if (ENABLE_FORTRAN)
 
     # tests
     add_executable(fortran_example-libint2 EXCLUDE_FROM_ALL fortran/fortran_example.F90)
-    target_link_libraries(fortran_example-libint2 ${int2_library} libint_f)
+    target_link_libraries(fortran_example-libint2 libint2 libint_f)
     target_include_directories(fortran_example-libint2 PRIVATE $<TARGET_PROPERTY:libint_f,Fortran_MODULE_DIRECTORY>)
 
     add_test(libint2/fortran_example/build "${CMAKE_COMMAND}" --build ${PROJECT_BINARY_DIR} --target fortran_example-libint2)

--- a/export/cmake/libint2-config.cmake.in
+++ b/export/cmake/libint2-config.cmake.in
@@ -63,8 +63,8 @@ endmacro(alias_target)
 # alias new target names to old namespaced targets
 alias_target(Libint2::int2 Libint2::libint2)
 alias_target(Libint2::int2-static Libint2::libint2-static)
-alias_target(Libint2::int2_static Libint2::libint2-static)
 alias_target(Libint2::Eigen Libint2::libint2_Eigen)
 alias_target(Libint2::cxx Libint2::libint2_cxx)
+alias_target(Libint2::cxx-static Libint2::libint2_cxx-static)
 
 set(LIBINT2_FOUND TRUE)

--- a/include/libint2/basis.h.in
+++ b/include/libint2/basis.h.in
@@ -620,15 +620,15 @@ namespace libint2 {
         return ref_shells;
       }
 
-      DEPRECATED static size_t nbf(const std::vector<libint2::Shell>& shells) {
+      LIBINT2_DEPRECATED static size_t nbf(const std::vector<libint2::Shell>& shells) {
         return libint2::nbf(shells);
       }
 
-      DEPRECATED static size_t max_nprim(const std::vector<libint2::Shell>& shells) {
+      LIBINT2_DEPRECATED static size_t max_nprim(const std::vector<libint2::Shell>& shells) {
         return libint2::max_nprim(shells);
       }
 
-      DEPRECATED static int max_l(const std::vector<libint2::Shell>& shells) {
+      LIBINT2_DEPRECATED static int max_l(const std::vector<libint2::Shell>& shells) {
         return libint2::max_l(shells);
       }
 

--- a/include/libint2/lcao/molden.h
+++ b/include/libint2/lcao/molden.h
@@ -250,7 +250,6 @@ class Export {
               "molden::Export cannot handle shells with l > 4");
 
         switch (contr.l) {
-          case 1:
           case 2:
           case 3:
           case 4: {
@@ -265,7 +264,7 @@ class Export {
           }
 
           default: {
-          }  // l = 0 is fine
+          }  // l = 0 && 1 are fine
         }
       }
     }

--- a/include/libint2/util/deprecated.h
+++ b/include/libint2/util/deprecated.h
@@ -21,15 +21,15 @@
 #ifndef _libint2_include_libint2_util_deprecated_h_
 #define _libint2_include_libint2_util_deprecated_h_
 
-#ifndef DEPRECATED  // avoid clashing with previous definitions
+#ifndef LIBINT2_DEPRECATED  // avoid clashing with previous definitions
 #if __cplusplus >= 201402L
-#define DEPRECATED [[deprecated]]
+#define LIBINT2_DEPRECATED [[deprecated]]
 #elif defined(__GNUC__)
-#define DEPRECATED __attribute__((deprecated))
+#define LIBINT2_DEPRECATED __attribute__((deprecated))
 #else
-#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
-#define DEPRECATED
+#pragma message("WARNING: You need to implement LIBINT2_DEPRECATED for this compiler")
+#define LIBINT2_DEPRECATED
 #endif
-#endif  // not defined(DEPRECATED)
+#endif  // not defined(LIBINT2_DEPRECATED)
 
 #endif /* header guard */


### PR DESCRIPTION
 it links against `STATIC` library ``libint2-static` if configured with `LIBINT2_BUILD_SHARED_AND_STATIC_LIBS=ON`

`libint2_cxx` now links against `libint2` which is a `SHARED` library