### PR TITLE
Include implicit cstdint

### DIFF
--- a/src/bin/libint/memory.h
+++ b/src/bin/libint/memory.h
@@ -21,6 +21,7 @@
 #include <limits.h>
 #include <smart_ptr.h>
 
+#include <cstdint>
 #include <list>
 
 #ifndef _libint2_src_bin_libint_memory_h_


### PR DESCRIPTION
Gcc-15 and unreleased clang-21 don't implicitly include it anymore for intptr_t.

https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes

Bug: https://bugs.gentoo.org/939020

```
clang++ -O2  -DHAVE_CONFIG_H  -D__COMPILING_LIBINT2=1 -I../../../src/bin -I../../../include -I/home/ask/sources/libint/src/bin/libint/../../../include -I/home/ask/sources/libint/src/bin/libint/../../../src/bin  -I/usr/include -I. -I/home/ask/sources/libint/src/bin/libint  -c -o memory.o memory.cc
In file included from memory.cc:23:
./memory.h:156:11: error: unknown type name 'intptr_t'; did you mean '__intptr_t'?
  156 |   typedef intptr_t Address;
      |           ^~~~~~~~
      |           __intptr_t
/usr/include/bits/types.h:207:25: note: '__intptr_t' declared here
  207 | __STD_TYPE __SWORD_TYPE __intptr_t;
      |                         ^
```