### PR TITLE
CMake: set target properties of Fortran tests

### DIFF
--- a/export/cmake/CMakeLists.txt.export
+++ b/export/cmake/CMakeLists.txt.export
@@ -579,6 +579,7 @@ if (ENABLE_FORTRAN)
 
     # tests
     add_executable(fortran_example-libint2 EXCLUDE_FROM_ALL fortran/fortran_example.F90)
+    set_target_properties(fortran_example-libint2 PROPERTIES LINKER_LANGUAGE Fortran)
     target_link_libraries(fortran_example-libint2 libint2 libint_f)
     target_include_directories(fortran_example-libint2 PRIVATE $<TARGET_PROPERTY:libint_f,Fortran_MODULE_DIRECTORY>)
 
@@ -591,6 +592,7 @@ if (ENABLE_FORTRAN)
 
     if (LIBINT_HAS_CXX_API)
         add_executable(fortran_test-libint2 EXCLUDE_FROM_ALL fortran/test.cc fortran/test-eri.cc $<TARGET_OBJECTS:libint_f>)
+        set_target_properties(fortran_test-libint2 PROPERTIES LINKER_LANGUAGE Fortran)
         target_link_libraries(fortran_test-libint2 libint2_cxx libint_f)
         target_include_directories(fortran_test-libint2 PRIVATE $<TARGET_PROPERTY:libint_f,Fortran_MODULE_DIRECTORY>)
         add_test(libint2/fortran_test/build "${CMAKE_COMMAND}" --build ${PROJECT_BINARY_DIR} --target fortran_test-libint2)


### PR DESCRIPTION
- The CXX compiler driver is used to link Fortran executables.
- The issue is exposed by, e.g., Intel Fortran Compiler.
- LINKER_LANGUAGE Fortran.