### PR TITLE
[python] engine.compute(bases) produces correct data layout

### DIFF
--- a/python/src/libint2/libint2.cc
+++ b/python/src/libint2/libint2.cc
@@ -138,9 +138,9 @@ std::vector<double> coeffs_normalized(const Shell &s) {
 
 PYBIND11_MODULE(libint2, m) {
   py::enum_<SHGShellOrdering>(m, "SHGShellOrdering")
-      .value("SHGShellOrdering_Standard", libint2::SHGShellOrdering_Standard)
-      .value("SHGShellOrdering_Gaussian", libint2::SHGShellOrdering_Gaussian)
-      .value("SHGShellOrdering_MOLDEN", libint2::SHGShellOrdering_Gaussian);
+      .value("Standard", libint2::SHGShellOrdering_Standard)
+      .value("Gaussian", libint2::SHGShellOrdering_Gaussian)
+      .value("MOLDEN", libint2::SHGShellOrdering_Gaussian);
 
   libint2::initialize();
 
@@ -251,6 +251,9 @@ PYBIND11_MODULE(libint2, m) {
   m.def("sto3g_num_ao", &libint2::sto3g_num_ao);
   m.def("sto3g_ao_occupation_vector",
         &libint2::sto3g_ao_occupation_vector<double>);
+
+  m.def("solid_harmonics_ordering", &libint2::solid_harmonics_ordering);
+  m.def("set_solid_harmonics_ordering", &libint2::set_solid_harmonics_ordering);
 
   using SolidHarmonicsCoefficients =
       libint2::solidharmonics::SolidHarmonicsCoefficients<double>;

--- a/python/tests/test_libint2.py
+++ b/python/tests/test_libint2.py
@@ -8,6 +8,7 @@ libint2.Engine.num_threads = 1
 
 s = Shell(0, [(1,10)])
 p = Shell(1, [(1,10)])
+d = Shell(2, [(1,10)], [0.1, 0.2, 0.3])
 
 h2o = [
   (8, [  0.00000, -0.07579, 0.00000 ]),
@@ -41,12 +42,12 @@ class TestLibint(unittest.TestCase):
       3.6563211198
     )
 
-    basis = [ s, p, s, p ]
-    self.assertAlmostEqual(libint2.overlap().compute(basis, basis).sum(), 16.0)
-    self.assertAlmostEqual(
-      norm(libint2.coulomb().compute(basis, basis, basis, basis)),
-      14.7036075402
-    )
+    if libint2.solid_harmonics_ordering() == libint2.SHGShellOrdering.Standard:
+        basis = [ p, d ]
+        S = libint2.overlap().compute(basis, basis)
+        self.assertAlmostEqual(S[0, 3], -0.08950980671097111)
+        self.assertAlmostEqual(S[0, 4], -0.26852942)
+        self.assertAlmostEqual(S[1, 3], 0.0055943629194356937)
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/unit/test-1body.cc
+++ b/tests/unit/test-1body.cc
@@ -243,3 +243,37 @@ TEST_CASE_METHOD(libint2::unit::DefaultFixture, "W correctness",
   }
 #endif  // LIBINT2_SUPPORT_ONEBODY
 }
+
+// verify that python/tests/test_libint2.py:test_integrals is correct
+TEST_CASE_METHOD(libint2::unit::DefaultFixture, "python correctness",
+                 "[engine][1-body]") {
+#if defined(LIBINT2_SUPPORT_ONEBODY)
+  std::vector<Shell> obs{Shell{{1.0}, {{1, true, {10.0}}}, {{0.0, 0.0, 0.0}}},
+                         Shell{{1.0}, {{2, true, {10.0}}}, {{0.1, 0.2, 0.3}}}};
+  constexpr int l0 = 1;
+  constexpr int l1 = 2;
+  constexpr int n1 = 2 * l1 + 1;
+
+  {
+    const auto lmax = LIBINT2_MAX_AM_overlap;
+    if (lmax >= 2) {
+      auto engine = Engine(Operator::overlap, 2, lmax);
+
+      engine.compute(obs[0], obs[1]);
+
+      // this is laid out in standard solids order
+      //      REQUIRE(engine.results()[0][0] == Approx(-0.08950980671097111));
+      //      REQUIRE(engine.results()[0][1] == Approx(-0.2685294201329133));
+      //      REQUIRE(engine.results()[0][5] == Approx(0.0055943629194356937));
+      std::vector<double> shellset_ref_standard = {
+          -0.0895098067109711,  -0.268529420132913, 0.114661696280563,
+          0.00559436291943569,  0.183681582521472,  0.00559436291943569,
+          -0.169695675222883,   -0.312493496201254, -0.0848478376114413,
+          -0.00419577218957676, -0.184613976341378, 0.00559436291943569,
+          0.0573308481402817,   -0.276920964512067, -0.0946379727204538};
+
+      LIBINT2_TEST_ONEBODY(1.0, 0);
+    }
+  }
+#endif  // LIBINT2_SUPPORT_ONEBODY
+}


### PR DESCRIPTION
numpy arrays are row-major, so no need to permute libint buffers when writing into them