### PR TITLE
feature: erfx_nuclear

### DIFF
--- a/include/libint2/lcao/1body.h
+++ b/include/libint2/lcao/1body.h
@@ -866,7 +866,7 @@ std::array<Matrix, libint2::operator_traits<obtype>::nopers> compute_1body_ints(
   // the nuclei are charges in this case; in QM/MM there will also be classical
   // charges
   if (obtype == Operator::nuclear || obtype == Operator::erf_nuclear ||
-      obtype == Operator::erfc_nuclear) {
+      obtype == Operator::erfc_nuclear || obtype == Operator::erfx_nuclear) {
     engines[0].set_params(params);
   }
   for (size_t i = 1; i != nthreads; ++i) {

--- a/tests/hartree-fock/hartree-fock++.cc
+++ b/tests/hartree-fock/hartree-fock++.cc
@@ -2391,21 +2391,28 @@ void api_basic_compile_test(const BasisSet& obs,
         compute_schwarz_ints<Operator::delcgtg2>(obs, obs, false, cgtg_params);
     std::cout << "||Del.cGTG||^2 Schwarz ints\n" << K << std::endl;
   }
-  double attenuation_omega = 1.0;
+  double attenuation_omega = 1.;
   {
-    auto K = compute_schwarz_ints<Operator::erfc_coulomb>(obs, obs, false,
-                                                          attenuation_omega);
-    std::cout << "erfc_coulomb Schwarz ints\n" << K << std::endl;
-  }
-  {
-    auto K = compute_schwarz_ints<Operator::erf_coulomb>(obs, obs, false,
-                                                         attenuation_omega);
-    std::cout << "erf_coulomb Schwarz ints\n" << K << std::endl;
-  }
-  {
-    auto K = compute_schwarz_ints<Operator::erfx_coulomb>(
-        obs, obs, false, {attenuation_omega, 0.2, 0.4});
-    std::cout << "erfx_coulomb Schwarz ints\n" << K << std::endl;
+    auto Q = compute_schwarz_ints<Operator::coulomb>(obs, obs, false);
+    std::cout << "coulomb Schwarz ints\n" << Q << std::endl;
+    auto Qerfc = compute_schwarz_ints<Operator::erfc_coulomb>(
+        obs, obs, false, attenuation_omega);
+    std::cout << "erfc_coulomb Schwarz ints\n" << Qerfc << std::endl;
+    auto Qerf = compute_schwarz_ints<Operator::erf_coulomb>(obs, obs, false,
+                                                            attenuation_omega);
+    std::cout << "erf_coulomb Schwarz ints\n" << Qerf << std::endl;
+    auto Qerfx11 = compute_schwarz_ints<Operator::erfx_coulomb>(
+        obs, obs, false, {attenuation_omega, 1., 1.});
+    std::cout << "||Q - Q_erfx11|| = " << Matrix(Q - Qerfx11).norm()
+              << std::endl;
+    auto Qerfx10 = compute_schwarz_ints<Operator::erfx_coulomb>(
+        obs, obs, false, {attenuation_omega, 1., 0.});
+    std::cout << "||Q_erf - Q_erfx10|| = " << Matrix(Qerf - Qerfx10).norm()
+              << std::endl;
+    auto Qerfx01 = compute_schwarz_ints<Operator::erfx_coulomb>(
+        obs, obs, false, {attenuation_omega, 0., 1.});
+    std::cout << "||Q_erfc - Q_erfx01|| = " << Matrix(Qerfc - Qerfx01).norm()
+              << std::endl;
   }
   {
     auto V = compute_1body_ints<Operator::nuclear>(
@@ -2419,7 +2426,28 @@ void api_basic_compile_test(const BasisSet& obs,
         obs, std::make_tuple(attenuation_omega,
                              libint2::make_point_charges(atoms)))[0];
     std::cout << "erf_nuclear ints\n" << V_erf << std::endl;
-    std::cout << "V - (V_erfc + V_erf)" << Matrix(V - V_erfc - V_erf)
+    std::cout << "||V - (V_erfc + V_erf)|| = " << (V - V_erfc - V_erf).norm()
+              << std::endl;
+    auto V_erfx11 = compute_1body_ints<Operator::erfx_nuclear>(
+        obs, std::make_tuple(std::array<double, 3>{attenuation_omega, 1., 1.},
+                             libint2::make_point_charges(atoms)))[0];
+    std::cout << "erfx_nuclear ints\n" << V_erfx11 << std::endl;
+    std::cout << "||V_erfx11 - V_erf - V_erfc|| = "
+              << (V_erfx11 - V_erf - V_erfc).norm() << std::endl;
+    auto V_erfx23 = compute_1body_ints<Operator::erfx_nuclear>(
+        obs, std::make_tuple(std::array<double, 3>{attenuation_omega, 2., 3.},
+                             libint2::make_point_charges(atoms)))[0];
+    std::cout << "||V_erfx23 - 2*V_erf - 3*V_erfc|| = "
+              << (V_erfx23 - 2 * V_erf - 3 * V_erfc).norm() << std::endl;
+    auto V_erfx20 = compute_1body_ints<Operator::erfx_nuclear>(
+        obs, std::make_tuple(std::array<double, 3>{attenuation_omega, 2., 0.},
+                             libint2::make_point_charges(atoms)))[0];
+    std::cout << "||V_erfx20 - 2*V_erf|| = " << (V_erfx20 - 2 * V_erf).norm()
+              << std::endl;
+    auto V_erfx03 = compute_1body_ints<Operator::erfx_nuclear>(
+        obs, std::make_tuple(std::array<double, 3>{attenuation_omega, 0., 3.},
+                             libint2::make_point_charges(atoms)))[0];
+    std::cout << "||V_erfx03 - 3*V_erfc|| = " << (V_erfx03 - 3 * V_erfc).norm()
               << std::endl;
   }
 


### PR DESCRIPTION
1-body analog of erfx_coulomb, for completeness

this also fixes erfc_{coulomb,nuclear} that were broken in 9f21b10540a216b5e2e1f0e03452c315241618a5 + minimally tests 2-body erf ints