### PR TITLE
add .gitattributes to build from git archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+cmake/modules/.git_archival.txt export-subst

--- a/cmake/modules/.git_archival.txt
+++ b/cmake/modules/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=?[0-9.]*)$
-ref-names: $Format:%D$


### PR DESCRIPTION
Was trying to build 2.13.0 release from git archive tarball, but it failed as `cmake/modules/.git_archival.txt` wasn't substituted causing:
```
fatal: not a git repository (or any of the parent directories): .git
CMake Error at cmake/modules/DynamicVersion.cmake:518 (message):
  Project source is neither a git repository nor a git archive:
```

Also removing `ref-names` which can lead to non-reproducible `git archive`, see: 
- https://github.com/pypa/setuptools-scm/commit/9ea57a006d737960f435af470023f7b2bf732ff7

---

On side note, currently unable to recursive clone repository. The wiki revision does not exist. Was this a local wiki change missing from remote?