### PR TITLE
Fix sstream_convert for types not constructible from const char*

### DIFF
--- a/include/libint2/numeric.h
+++ b/include/libint2/numeric.h
@@ -198,6 +198,22 @@ inline int get_max_digits10(const Real& value) {
   return std::numeric_limits<Real>::max_digits10;
 }
 
+namespace detail {
+template <typename To>
+typename std::enable_if<std::is_constructible<To, const char*>::value, To>::type
+sstream_convert_extract(std::stringstream& ss) {
+  return To(ss.str().c_str());
+}
+
+template <typename To>
+typename std::enable_if<!std::is_constructible<To, const char*>::value, To>::type
+sstream_convert_extract(std::stringstream& ss) {
+  To to;
+  ss >> to;
+  return to;
+}
+}  // namespace detail
+
 template <typename To, typename From>
 typename std::enable_if<!std::is_same<typename std::decay<To>::type,
                                       typename std::decay<From>::type>::value,
@@ -205,8 +221,7 @@ typename std::enable_if<!std::is_same<typename std::decay<To>::type,
 sstream_convert(From&& from) {
   std::stringstream ss;
   ss << std::scientific << std::setprecision(get_max_digits10(from)) << from;
-  To to(ss.str().c_str());
-  return to;
+  return detail::sstream_convert_extract<To>(ss);
 }
 
 template <typename To>


### PR DESCRIPTION
## Summary

- `sstream_convert<To>` constructs the destination as `To to(ss.str().c_str())`, which only compiles when `To` accepts a `const char*` (e.g. `mpf_class`). Instantiations with `To = double` from `tests/unit/test-core-ints.cc` fail to compile under gcc 16.
- Dispatch via SFINAE: keep the `c_str()` construction for types constructible from `const char*` (preserves the existing `mpf_class` precision-via-string path), and use stream extraction (`To to; ss >> to;`) for everything else (`double`, etc.).

Fixes #417

## Test plan

- [ ] `unit_tests-libint2` builds with gcc 16 and `LIBINT_HAS_MPFR=1`
- [ ] `libint2/unit/run` and `libint2/unit/sho=gaussian/run` ctest targets pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)