### PR TITLE
Silence compiler warnings in molden.h and build_libint.cc

### DIFF
--- a/include/libint2/lcao/molden.h
+++ b/include/libint2/lcao/molden.h
@@ -280,7 +280,7 @@ class Export {
   void initialize_bf_map() {
     atom2shell_ = BasisSet::atom2shell(atoms_, basis_);
 
-    const auto nao = BasisSet::nbf(basis_);
+    const auto nao = libint2::nbf(basis_);
     ao_map_.resize(nao);
     assert(nao == coefs_.rows());
     const auto shell2ao = BasisSet::compute_shell2bf(basis_);
@@ -314,7 +314,8 @@ class Export {
               ao_molden += 3;
             } else {
               FOR_SOLIDHARM_MOLDEN(l, m)
-              const auto ao_in_shell = libint2::INT_SOLIDHARMINDEX(l, m);
+              const auto ao_in_shell = libint2::INT_SOLIDHARMINDEX(
+                  libint2::solid_harmonics_ordering(), l, m);
               ao_map_[ao_molden++] = ao + ao_in_shell;
               END_FOR_SOLIDHARM_MOLDEN
             }

--- a/src/bin/libint/build_libint.cc
+++ b/src/bin/libint/build_libint.cc
@@ -1782,7 +1782,7 @@ void build_R12kG12_2b_2k(std::ostream& os,
 #endif  // LIBINT_INCLUDE_G12
 
 #ifdef LIBINT_INCLUDE_G12
-void build_R12kG12_2b_2k_separate(
+[[maybe_unused]] void build_R12kG12_2b_2k_separate(
     std::ostream& os, const std::shared_ptr<CompilationParameters>& cparams,
     std::shared_ptr<Libint2Iface>& iface) {
   // do not support this if the commutator integrals are needed


### PR DESCRIPTION
## Summary
- `molden.h`: use `libint2::nbf` instead of the deprecated `BasisSet::nbf`, and pass `libint2::solid_harmonics_ordering()` to `INT_SOLIDHARMINDEX` to match the current API.
- `build_libint.cc`: mark `build_R12kG12_2b_2k_separate` `[[maybe_unused]]` since it is only referenced under specific configurations.

## Test plan
- [ ] Build with a warnings-enabled compiler (e.g. recent clang/gcc) and confirm the previously emitted warnings for these two files are gone.
- [ ] Run the existing test suite to confirm no behavior change.