### PR TITLE
Fix installed basis.h getting restrictive (0600) permissions

### DIFF
--- a/export/CMakeLists.txt.export
+++ b/export/CMakeLists.txt.export
@@ -785,15 +785,23 @@ install(
 # install basis.h at install time so LIBINT_DATADIR_ABSOLUTE reflects
 # any --prefix override. $ENV{DESTDIR} must be prepended manually
 # here: install(CODE) runs custom code and does not get the automatic
-# DESTDIR handling that install(FILES) etc. have.
+# DESTDIR handling that install(FILES) etc. have. configure_file into the
+# build tree, then file(COPY) into the install tree with explicit
+# FILE_PERMISSIONS so the installed header does not inherit basis.h.in's
+# mode (e.g. 0600, which varies by build env); this also works with the
+# 3.16 minimum required here, unlike configure_file's NO_SOURCE_PERMISSIONS
+# (CMake 3.19+).
 install(CODE "
   set(LIBINT_VERSION \"${LIBINT_VERSION}\")
   set(LIBINT_DATADIR_ABSOLUTE \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/libint/${LIBINT_VERSION}\")
   configure_file(
     \"${PROJECT_SOURCE_DIR}/include/libint2/basis.h.in\"
-    \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}/libint2/basis.h\"
-    @ONLY
-    NO_SOURCE_PERMISSIONS)  # else installed basis.h inherits basis.h.in's perms (e.g. 0600), which vary by build env
+    \"${PROJECT_BINARY_DIR}/basis.h.install/basis.h\"
+    @ONLY)
+  file(COPY
+    \"${PROJECT_BINARY_DIR}/basis.h.install/basis.h\"
+    DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}/libint2\"
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 ")
 
 # install bundled Boost headers if needed

--- a/export/CMakeLists.txt.export
+++ b/export/CMakeLists.txt.export
@@ -792,7 +792,8 @@ install(CODE "
   configure_file(
     \"${PROJECT_SOURCE_DIR}/include/libint2/basis.h.in\"
     \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIBINT2_INSTALL_INCLUDEDIR}/libint2/basis.h\"
-    @ONLY)
+    @ONLY
+    NO_SOURCE_PERMISSIONS)  # else installed basis.h inherits basis.h.in's perms (e.g. 0600), which vary by build env
 ")
 
 # install bundled Boost headers if needed

--- a/src/lib/libint/CMakeLists.txt
+++ b/src/lib/libint/CMakeLists.txt
@@ -227,14 +227,22 @@ else()
         )
     endforeach()
 
-    # generate basis.h at install time so LIBINT_DATADIR_ABSOLUTE reflects any --prefix override
+    # generate basis.h at install time so LIBINT_DATADIR_ABSOLUTE reflects any --prefix override.
+    # configure_file into the build tree, then file(COPY) into the install tree with explicit
+    # FILE_PERMISSIONS: this avoids the installed header inheriting basis.h.in's mode (e.g. 0600,
+    # which varies by build env) without relying on NO_SOURCE_PERMISSIONS, and prepends
+    # $ENV{DESTDIR} manually -- install(CODE) runs custom code and does not get the automatic
+    # DESTDIR handling that install(FILES) etc. have.
     install(CODE "
       set(LIBINT_VERSION \"${LIBINT_VERSION}\")
       set(LIBINT_DATADIR_ABSOLUTE \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/libint/${LIBINT_VERSION}\")
       configure_file(
         \"${PROJECT_SOURCE_DIR}/include/libint2/basis.h.in\"
-        \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/libint2/basis.h\"
-        @ONLY
-        NO_SOURCE_PERMISSIONS)  # else installed basis.h inherits basis.h.in's perms (e.g. 0600), which vary by build env
+        \"${CMAKE_CURRENT_BINARY_DIR}/basis.h.install/basis.h\"
+        @ONLY)
+      file(COPY
+        \"${CMAKE_CURRENT_BINARY_DIR}/basis.h.install/basis.h\"
+        DESTINATION \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/libint2\"
+        FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
     ")
 endif()

--- a/src/lib/libint/CMakeLists.txt
+++ b/src/lib/libint/CMakeLists.txt
@@ -234,6 +234,7 @@ else()
       configure_file(
         \"${PROJECT_SOURCE_DIR}/include/libint2/basis.h.in\"
         \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/libint2/basis.h\"
-        @ONLY)
+        @ONLY
+        NO_SOURCE_PERMISSIONS)  # else installed basis.h inherits basis.h.in's perms (e.g. 0600), which vary by build env
     ")
 endif()


### PR DESCRIPTION
## Problem

On some Linux installs the installed `include/libint2/basis.h` ends up with `0600` permissions (owner-only), making it unreadable to other users, while every other installed header is `0644`. macOS installs are unaffected.

## Root cause

`basis.h` is the **only** public header generated directly during install via `install(CODE …)`, so it does not go through `install(FILES)` normalization. If generated/copied with source-permission inheritance, restrictive mode bits from `basis.h.in` can propagate to the installed header.

## Fix

Avoid source-permission inheritance entirely and explicitly install `basis.h` as `0644` in a CMake-3.16-compatible way:

- `configure_file()` now generates `basis.h` into the build tree first.
- `file(COPY … FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)` then copies it into the install include directory, pinning installed mode to `0644`.
- The in-tree install path now also prepends `$ENV{DESTDIR}` so staged/package installs land in the staging root correctly.

Applied in both:
- `export/CMakeLists.txt.export` (exported project used by end users)
- `src/lib/libint/CMakeLists.txt` (generator in-tree copy)