### PR TITLE
CMake: Make libint2 Fortran interface explicit

### DIFF
--- a/cmake/libint2-config.cmake.in
+++ b/cmake/libint2-config.cmake.in
@@ -40,6 +40,7 @@
 #   oo - search for           + orca      = orca
 #   bs - search for  bagel    + standard  = bagel
 #   bo - search for           + orca
+#   Fortran - require the Fortran interface target
 
 @PACKAGE_INIT@
 
@@ -54,6 +55,8 @@ list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
 # check library language component
 include(CMakeFindDependencyMacro)
+
+set(${L2}_Fortran_FOUND @LIBINT2_ENABLE_FORTRAN@)
 
     if(NOT TARGET Eigen3::Eigen)
       set(Eigen3_CONFIG @Eigen3_CONFIG@)

--- a/export/CMakeLists.txt.export
+++ b/export/CMakeLists.txt.export
@@ -125,6 +125,10 @@ set(LIBINT2_INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}/libint/${LIBINT_VERSION}"
 set(LIBINT2_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/libint2"
         CACHE PATH "LIBINT2 CMAKE install directory")
 
+if(NOT CMAKE_INSTALL_Fortran_MODULES)
+    set(CMAKE_INSTALL_Fortran_MODULES "${LIBINT2_INSTALL_INCLUDEDIR}")
+endif()
+
 
 # ====  Dependencies  ===========================================================
 
@@ -668,21 +672,13 @@ if (LIBINT2_ENABLE_FORTRAN)
       )
 
     # build module
-    add_library(
-      libint_f
-      OBJECT
-        fortran/libint_f.F90
-      )
+    add_library(libint_f OBJECT fortran/libint_f.F90)
     set_source_files_properties(
       fortran/libint_f.F90
       PROPERTIES
         OBJECT_DEPENDS "${PROJECT_BINARY_DIR}/fortran/libint2_types_f.h;${PROJECT_BINARY_DIR}/fortran/fortran_incldefs.h"
       )
-    target_compile_definitions(
-      libint_f
-      PRIVATE
-        __COMPILING_LIBINT2
-      )
+    target_compile_definitions(libint_f PRIVATE __COMPILING_LIBINT2)
     set_target_properties(
       libint_f
       PROPERTIES
@@ -698,6 +694,21 @@ if (LIBINT2_ENABLE_FORTRAN)
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/fortran>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/${BUILDTREE_FMODDIR}/>
+      )
+
+    add_library(int_f STATIC $<TARGET_OBJECTS:libint_f>)
+    set_target_properties(int_f PROPERTIES OUTPUT_NAME "int2_f")
+    if (L2_BUILD_SHARED_LIBS)
+        target_link_libraries(int_f INTERFACE int-shared)
+    else()
+        target_link_libraries(int_f INTERFACE int-static)
+    endif()
+    target_include_directories(
+      int_f
+      INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/fortran>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/${BUILDTREE_FMODDIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_Fortran_MODULES}>
       )
 
     # Fortran tests merged into rest of tests
@@ -732,6 +743,9 @@ if (L2_BUILD_SHARED_LIBS)
 endif()
 if (L2_BUILD_STATIC_LIBS)
     list(APPEND _libint2_install_targets int-static)
+endif()
+if (LIBINT2_ENABLE_FORTRAN)
+    list(APPEND _libint2_install_targets int_f)
 endif()
 
 install(
@@ -839,7 +853,7 @@ endif()
 if (LIBINT2_ENABLE_FORTRAN)
     install(
       DIRECTORY ${PROJECT_BINARY_DIR}/${BUILDTREE_FMODDIR}/
-      DESTINATION "${LIBINT2_INSTALL_INCLUDEDIR}"
+      DESTINATION "${CMAKE_INSTALL_Fortran_MODULES}"
       )
 endif()
 

--- a/export/tests/CMakeLists.txt
+++ b/export/tests/CMakeLists.txt
@@ -242,10 +242,6 @@ endif (LIBINT2_REQUIRE_CXX_API)
 
 if (LIBINT2_ENABLE_FORTRAN)
 
-    # Note: if forming compile line by hand rather than using targets, you'll
-    #   need to include the Fortran module file directory:
-    #   `target_include_directories(... PRIVATE $<TARGET_PROPERTY:libint_f,Fortran_MODULE_DIRECTORY>)`
-
     add_executable(
       fortran_example-libint2
       EXCLUDE_FROM_ALL
@@ -254,8 +250,7 @@ if (LIBINT2_ENABLE_FORTRAN)
     target_link_libraries(
       fortran_example-libint2
       PRIVATE
-        Libint2::int2
-        libint_f
+        int_f
       )
     add_test(  # Test #14
       NAME libint2/fortran_example/build
@@ -283,14 +278,13 @@ if (LIBINT2_ENABLE_FORTRAN)
           EXCLUDE_FROM_ALL
           fortran/test.cc
           fortran/test-eri.cc
-          $<TARGET_OBJECTS:libint_f>
           )
         target_link_libraries(
           fortran_test-libint2
           PRIVATE
             $<IF:$<TARGET_EXISTS:Libint2::int2-cxx>,Libint2::int2-cxx,Libint2::cxx>
             # N.B. cxx compiled library if LIBINT2_REQUIRE_CXX_API_COMPILED=ON else header-only library
-            libint_f
+            int_f
           )
         add_test(  # Test #16
           NAME libint2/fortran_test/build


### PR DESCRIPTION
Libint2 currently installs the `libint_f.mod` module file without exporting a corresponding CMake target. As a result, downstream projects have to locate compiler-specific Fortran module directories manually.

Introduce an installable `int_f` wrapper library, exported as `Libint2::int_f`. Linking this target provides the Fortran wrapper library, the underlying Libint2 library, and the correct module include directory through its usage requirements.

The Fortran module installation directory is now controlled by `CMAKE_INSTALL_Fortran_MODULES`, defaulting to the existing include-directory location. Distribution packages (Fedora RPM-build) can override it at configure time, avoiding post-install relocation of `libint_f.mod`.

This allows downstream projects to consume the Fortran interface through the exported package metadata rather than searching for `libint_f.mod` themselves.